### PR TITLE
Add default role definitions for apps

### DIFF
--- a/compliance.json
+++ b/compliance.json
@@ -1,0 +1,18 @@
+{
+  "roles": [
+    {
+      "name": "Compliance Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "compliance:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    }
+  ]
+}

--- a/drift.json
+++ b/drift.json
@@ -1,0 +1,18 @@
+{
+  "roles": [
+    {
+      "name": "Drift Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "drift:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    }
+  ]
+}

--- a/insights.json
+++ b/insights.json
@@ -1,0 +1,18 @@
+{
+  "roles": [
+    {
+      "name": "Insights Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "insights:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    }
+  ]
+}

--- a/vulnerability.json
+++ b/vulnerability.json
@@ -1,0 +1,18 @@
+{
+  "roles": [
+    {
+      "name": "Vulnerability Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "vulnerability:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds default role definitions for the following applications:

Compliance
Insights
Drift
Vulnerability

Each of these applications needs a base, global read/write permission for
itself, as well as inventory, which is a dependent service which will be
receiving permissions from the upstream service. These permissions are set on
a base role for each application.

PR migrated from https://github.com/RedHatInsights/insights-rbac/pull/138