### PR TITLE
Add default role definitions for more apps

### DIFF
--- a/configs/ansible-automation.json
+++ b/configs/ansible-automation.json
@@ -1,0 +1,18 @@
+{
+  "roles": [
+    {
+      "name": "Ansible-automation Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "ansible-automation:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    }
+  ]
+}

--- a/configs/ansible-hub.json
+++ b/configs/ansible-hub.json
@@ -1,0 +1,18 @@
+{
+  "roles": [
+    {
+      "name": "Ansible-hub Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "ansible-hub:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    }
+  ]
+}

--- a/configs/remediations.json
+++ b/configs/remediations.json
@@ -1,0 +1,18 @@
+{
+  "roles": [
+    {
+      "name": "Remediations Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "remediations:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    }
+  ]
+}

--- a/configs/subscriptions.json
+++ b/configs/subscriptions.json
@@ -1,0 +1,18 @@
+{
+  "roles": [
+    {
+      "name": "Subscriptions Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "subscriptions:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds default role definitions for the following applications:

* ansible-automation
* ansible-hub
* remediations
* subscriptions

Each of these applications needs a base, global read/write permission for
itself, as well as inventory, which is a dependent service which will be
receiving permissions from the upstream service. These permissions are set on
a base role for each application.