### PR TITLE
Added new configs for each of the apps & platform_default flag

### DIFF
--- a/configs/ansible-automation.json
+++ b/configs/ansible-automation.json
@@ -1,0 +1,19 @@
+{
+    "roles": [
+      {
+        "name": "Ansible Automation Access",
+        "description": "An all access role which grants read and write permissions.",
+        "system": true,
+        "platform_default": true,
+        "version": 2,
+        "access": [
+          {
+            "permission": "ansible-automation:*:*"
+          },
+          {
+            "permission": "inventory:*:*"
+          }
+        ]
+      }
+    ]
+  }

--- a/configs/ansible-hub.json
+++ b/configs/ansible-hub.json
@@ -1,0 +1,19 @@
+{
+    "roles": [
+      {
+        "name": "Ansible Hub Access",
+        "description": "An all access role which grants read and write permissions.",
+        "system": true,
+        "platform_default": true,
+        "version": 2,
+        "access": [
+          {
+            "permission": "ansible-hub:*:*"
+          },
+          {
+            "permission": "inventory:*:*"
+          }
+        ]
+      }
+    ]
+  }

--- a/configs/catalog.json
+++ b/configs/catalog.json
@@ -1,6 +1,21 @@
 {
   "roles": [
     {
+      "name": "Catalog Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "platform_default": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "catalog:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    },
+    {
       "name": "Catalog Administrator",
       "system": true,
       "version": 4,
@@ -70,8 +85,8 @@
     },
     {
       "name": "Catalog User",
-      "system": true,
       "version": 4,
+      "system": true,
       "description": "A catalog user roles grants read and order permissions",
       "access": [
         {

--- a/configs/compliance.json
+++ b/configs/compliance.json
@@ -4,7 +4,8 @@
       "name": "Compliance Access",
       "description": "An all access role which grants read and write permissions.",
       "system": true,
-      "version": 2,
+      "platform_default": true,
+      "version": 3,
       "access": [
         {
           "permission": "compliance:*:*"

--- a/configs/drift.json
+++ b/configs/drift.json
@@ -4,7 +4,8 @@
       "name": "Drift Access",
       "description": "An all access role which grants read and write permissions.",
       "system": true,
-      "version": 2,
+      "platform_default": true,
+      "version": 3,
       "access": [
         {
           "permission": "drift:*:*"

--- a/configs/insights.json
+++ b/configs/insights.json
@@ -4,7 +4,8 @@
       "name": "Insights Access",
       "description": "An all access role which grants read and write permissions.",
       "system": true,
-      "version": 2,
+      "platform_default": true,
+      "version": 3,
       "access": [
         {
           "permission": "insights:*:*"

--- a/configs/remediations.json
+++ b/configs/remediations.json
@@ -1,0 +1,19 @@
+{
+    "roles": [
+      {
+        "name": "Remediations Access",
+        "description": "An all access role which grants read and write permissions.",
+        "system": true,
+        "platform_default": true,
+        "version": 2,
+        "access": [
+          {
+            "permission": "remediations:*:*"
+          },
+          {
+            "permission": "inventory:*:*"
+          }
+        ]
+      }
+    ]
+  }

--- a/configs/subscriptions.json
+++ b/configs/subscriptions.json
@@ -1,0 +1,18 @@
+{
+    "roles": [
+      {
+        "name": "Subscriptions Access",
+        "description": "An all access role which grants read and write permissions.",
+        "system": true,
+        "version": 2,
+        "access": [
+          {
+            "permission": "subscriptions:*:*"
+          },
+          {
+            "permission": "inventory:*:*"
+          }
+        ]
+      }
+    ]
+  }

--- a/configs/vulnerability.json
+++ b/configs/vulnerability.json
@@ -4,7 +4,8 @@
       "name": "Vulnerability Access",
       "description": "An all access role which grants read and write permissions.",
       "system": true,
-      "version": 2,
+      "platform_default": true,
+      "version": 3,
       "access": [
         {
           "permission": "vulnerability:*:*"


### PR DESCRIPTION
Using Nicole's doc for the RBAC Lite Rollout Plan I updated each of the config files to represent the default permissions that should be given to each application upon startup of the RBAC service.  

I also added the **platform_default** flag that @wcmitchell recently implemented to each of the apps that were marked as _full access_ in the docs.

Nicole's RBAC Lite Rollout doc:
https://docs.google.com/document/d/1gpla2N7HMr3snk8tJsMwQ3LDBmEzQQTjBekROLVTYv0/edit