### PR TITLE
Bump `platform_default` role versions

### DIFF
--- a/configs/ansible-automation.json
+++ b/configs/ansible-automation.json
@@ -5,7 +5,7 @@
         "description": "An all access role which grants read and write permissions.",
         "system": true,
         "platform_default": true,
-        "version": 2,
+        "version": 3,
         "access": [
           {
             "permission": "ansible-automation:*:*"

--- a/configs/ansible-hub.json
+++ b/configs/ansible-hub.json
@@ -5,7 +5,7 @@
         "description": "An all access role which grants read and write permissions.",
         "system": true,
         "platform_default": true,
-        "version": 2,
+        "version": 3,
         "access": [
           {
             "permission": "ansible-hub:*:*"

--- a/configs/catalog.json
+++ b/configs/catalog.json
@@ -5,7 +5,7 @@
       "description": "An all access role which grants read and write permissions.",
       "system": true,
       "platform_default": true,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "catalog:*:*"

--- a/configs/compliance.json
+++ b/configs/compliance.json
@@ -5,7 +5,7 @@
       "description": "An all access role which grants read and write permissions.",
       "system": true,
       "platform_default": true,
-      "version": 3,
+      "version": 4,
       "access": [
         {
           "permission": "compliance:*:*"

--- a/configs/drift.json
+++ b/configs/drift.json
@@ -5,7 +5,7 @@
       "description": "An all access role which grants read and write permissions.",
       "system": true,
       "platform_default": true,
-      "version": 3,
+      "version": 4,
       "access": [
         {
           "permission": "drift:*:*"

--- a/configs/insights.json
+++ b/configs/insights.json
@@ -5,7 +5,7 @@
       "description": "An all access role which grants read and write permissions.",
       "system": true,
       "platform_default": true,
-      "version": 3,
+      "version": 4,
       "access": [
         {
           "permission": "insights:*:*"

--- a/configs/remediations.json
+++ b/configs/remediations.json
@@ -5,7 +5,7 @@
         "description": "An all access role which grants read and write permissions.",
         "system": true,
         "platform_default": true,
-        "version": 2,
+        "version": 3,
         "access": [
           {
             "permission": "remediations:*:*"

--- a/configs/vulnerability.json
+++ b/configs/vulnerability.json
@@ -5,7 +5,7 @@
       "description": "An all access role which grants read and write permissions.",
       "system": true,
       "platform_default": true,
-      "version": 3,
+      "version": 4,
       "access": [
         {
           "permission": "vulnerability:*:*"


### PR DESCRIPTION
The `platform_default` roles were added to the config _before_ the application
logic to modify the seed script was added to the RBAC repo in: https://github.com/RedHatInsights/insights-rbac/pull/161
Since CI is built off of changes to this repo's `master` branch, those roles
were then added to all CI tenant schemas, _without_ the `platform_default`
flag being set on those roles.

Once the seeding logic went in, since the roles existed and the versions were the
same, the CI schemas did not pick up the `platform_default` role changes, and thus
the platform default groups in CI do not have these roles attached.

This change forces an update to the default roles, to ensure the default groups
pick them up in the seeds.