### PR TITLE
Changed the platform default role to Catalog User for Catalog Service

### DIFF
--- a/configs/catalog.json
+++ b/configs/catalog.json
@@ -1,21 +1,6 @@
 {
   "roles": [
     {
-      "name": "Catalog Access",
-      "description": "An all access role which grants read and write permissions.",
-      "system": true,
-      "platform_default": true,
-      "version": 3,
-      "access": [
-        {
-          "permission": "catalog:*:*"
-        },
-        {
-          "permission": "inventory:*:*"
-        }
-      ]
-    },
-    {
       "name": "Catalog Administrator",
       "system": true,
       "version": 4,
@@ -85,8 +70,9 @@
     },
     {
       "name": "Catalog User",
-      "version": 4,
+      "version": 5,
       "system": true,
+      "platform_default": true,
       "description": "A catalog user roles grants read and order permissions",
       "access": [
         {

--- a/configs/catalog.json
+++ b/configs/catalog.json
@@ -1,6 +1,21 @@
 {
   "roles": [
     {
+      "name": "Catalog Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "platform_default": false,
+      "version": 4,
+      "access": [
+        {
+          "permission": "catalog:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    },
+    {
       "name": "Catalog Administrator",
       "system": true,
       "version": 4,
@@ -70,9 +85,8 @@
     },
     {
       "name": "Catalog User",
-      "version": 5,
+      "version": 4,
       "system": true,
-      "platform_default": true,
       "description": "A catalog user roles grants read and order permissions",
       "access": [
         {

--- a/configs/catalog.json
+++ b/configs/catalog.json
@@ -1,21 +1,6 @@
 {
   "roles": [
     {
-      "name": "Catalog Access",
-      "description": "An all access role which grants read and write permissions.",
-      "system": true,
-      "platform_default": false,
-      "version": 4,
-      "access": [
-        {
-          "permission": "catalog:*:*"
-        },
-        {
-          "permission": "inventory:*:*"
-        }
-      ]
-    },
-    {
       "name": "Catalog Administrator",
       "system": true,
       "version": 4,
@@ -85,8 +70,9 @@
     },
     {
       "name": "Catalog User",
-      "version": 4,
+      "version": 5,
       "system": true,
+      "platform_default": true,
       "description": "A catalog user roles grants read and order permissions",
       "access": [
         {

--- a/configs/catalog.json
+++ b/configs/catalog.json
@@ -1,6 +1,21 @@
 {
   "roles": [
     {
+      "name": "Catalog Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "platform_default": false,
+      "version": 4,
+      "access": [
+        {
+          "permission": "catalog:*:*"
+        },
+        {
+          "permission": "inventory:*:*"
+        }
+      ]
+    },
+    {
       "name": "Catalog Administrator",
       "system": true,
       "version": 4,
@@ -72,8 +87,8 @@
       "name": "Catalog User",
       "version": 5,
       "system": true,
-      "platform_default": true,
       "description": "A catalog user roles grants read and order permissions",
+      "platform_default": true,
       "access": [
         {
           "permission": "catalog:portfolios:read"


### PR DESCRIPTION
The Catalog User has restricted access to the objects in Catalog,
during onboarding a user can be given the role of Catalog Administrator
or Catalog User. This PR removes the Catalog Access which was had the
platform_default set to true.