### PR TITLE
Remove implicit inventory permissions

### DIFF
--- a/configs/compliance.json
+++ b/configs/compliance.json
@@ -5,13 +5,10 @@
       "description": "An all access role which grants read and write permissions.",
       "system": true,
       "platform_default": true,
-      "version": 4,
+      "version": 5,
       "access": [
         {
           "permission": "compliance:*:*"
-        },
-        {
-          "permission": "inventory:*:*"
         }
       ]
     }

--- a/configs/drift.json
+++ b/configs/drift.json
@@ -5,13 +5,10 @@
       "description": "An all access role which grants read and write permissions.",
       "system": true,
       "platform_default": true,
-      "version": 4,
+      "version": 5,
       "access": [
         {
           "permission": "drift:*:*"
-        },
-        {
-          "permission": "inventory:*:*"
         }
       ]
     }

--- a/configs/insights.json
+++ b/configs/insights.json
@@ -5,13 +5,10 @@
       "description": "An all access role which grants read and write permissions.",
       "system": true,
       "platform_default": true,
-      "version": 4,
+      "version": 5,
       "access": [
         {
           "permission": "insights:*:*"
-        },
-        {
-          "permission": "inventory:*:*"
         }
       ]
     }

--- a/configs/remediations.json
+++ b/configs/remediations.json
@@ -5,16 +5,13 @@
       "description": "A role which grants read and write permissions.",
       "system": true,
       "platform_default": true,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "remediations:remediation:read"
         },
         {
           "permission": "remediations:remediation:write"
-        },
-        {
-          "permission": "inventory:*:*"
         }
       ]
     }

--- a/configs/vulnerability.json
+++ b/configs/vulnerability.json
@@ -5,13 +5,10 @@
       "description": "An all access role which grants read and write permissions.",
       "system": true,
       "platform_default": true,
-      "version": 4,
+      "version": 5,
       "access": [
         {
           "permission": "vulnerability:*:*"
-        },
-        {
-          "permission": "inventory:*:*"
         }
       ]
     }


### PR DESCRIPTION
We need to remove all implicit inventory permissions from the
default platform roles, and bump the default role versions to
ensure the permissions are removed when seeding is run.