### PR TITLE
Add system patch manager default role to QA

### DIFF
--- a/configs/patch.json
+++ b/configs/patch.json
@@ -1,0 +1,16 @@
+{
+  "roles": [
+    {
+      "name": "Patchman Access",
+      "description": "An all access role which grants read and write permissions.",
+      "system": true,
+      "platform_default": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "patch:*:*"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Just copied from master, running on CI.

Pending app  name finalization before changing default role name.