### PR TITLE
Update the platform default role names and descriptions

### DIFF
--- a/configs/compliance.json
+++ b/configs/compliance.json
@@ -1,8 +1,8 @@
 {
   "roles": [
     {
-      "name": "Compliance Access",
-      "description": "An all access role which grants read and write permissions.",
+      "name": "Compliance administrator",
+      "description": "Perform any available operation against any Compliance resource.",
       "system": true,
       "platform_default": true,
       "version": 5,

--- a/configs/compliance.json
+++ b/configs/compliance.json
@@ -5,7 +5,7 @@
       "description": "Perform any available operation against any Compliance resource.",
       "system": true,
       "platform_default": true,
-      "version": 5,
+      "version": 6,
       "access": [
         {
           "permission": "compliance:*:*"

--- a/configs/drift.json
+++ b/configs/drift.json
@@ -5,7 +5,7 @@
       "description": "Perform any available operation against any Drift Analysis resource.",
       "system": true,
       "platform_default": true,
-      "version": 5,
+      "version": 6,
       "access": [
         {
           "permission": "drift:*:*"

--- a/configs/drift.json
+++ b/configs/drift.json
@@ -1,8 +1,8 @@
 {
   "roles": [
     {
-      "name": "Drift Access",
-      "description": "An all access role which grants read and write permissions.",
+      "name": "Drift analysis administrator",
+      "description": "Perform any available operation against any Drift Analysis resource.",
       "system": true,
       "platform_default": true,
       "version": 5,

--- a/configs/insights.json
+++ b/configs/insights.json
@@ -1,8 +1,8 @@
 {
   "roles": [
     {
-      "name": "Insights Access",
-      "description": "An all access role which grants read and write permissions.",
+      "name": "Insights administrator",
+      "description": "Perform any available operation against any Insights resource.",
       "system": true,
       "platform_default": true,
       "version": 5,

--- a/configs/insights.json
+++ b/configs/insights.json
@@ -5,7 +5,7 @@
       "description": "Perform any available operation against any Insights resource.",
       "system": true,
       "platform_default": true,
-      "version": 5,
+      "version": 6,
       "access": [
         {
           "permission": "insights:*:*"

--- a/configs/patch.json
+++ b/configs/patch.json
@@ -1,8 +1,8 @@
 {
   "roles": [
     {
-      "name": "Patchman Access",
-      "description": "An all access role which grants read and write permissions.",
+      "name": "System patch manager administrator",
+      "description": "Perform any available operation against any System Patch Manager resource.",
       "system": true,
       "platform_default": true,
       "version": 2,

--- a/configs/patch.json
+++ b/configs/patch.json
@@ -1,8 +1,8 @@
 {
   "roles": [
     {
-      "name": "System patch manager administrator",
-      "description": "Perform any available operation against any System Patch Manager resource.",
+      "name": "Patchman Access",
+      "description": "An all access role which grants read and write permissions.",
       "system": true,
       "platform_default": true,
       "version": 2,

--- a/configs/remediations.json
+++ b/configs/remediations.json
@@ -1,8 +1,8 @@
 {
   "roles": [
     {
-      "name": "Remediations Access",
-      "description": "A role which grants read and write permissions.",
+      "name": "Remediations user",
+      "description": "Perform create, view, update, delete operations against any Remediations resource.",
       "system": true,
       "platform_default": true,
       "version": 3,

--- a/configs/remediations.json
+++ b/configs/remediations.json
@@ -5,7 +5,7 @@
       "description": "Perform create, view, update, delete operations against any Remediations resource.",
       "system": true,
       "platform_default": true,
-      "version": 3,
+      "version": 4,
       "access": [
         {
           "permission": "remediations:remediation:read"

--- a/configs/vulnerability.json
+++ b/configs/vulnerability.json
@@ -1,8 +1,8 @@
 {
   "roles": [
     {
-      "name": "Vulnerability Access",
-      "description": "An all access role which grants read and write permissions.",
+      "name": "Vulnerabilities administrator",
+      "description": "Perform any available operation against any Vulnerability resource.",
       "system": true,
       "platform_default": true,
       "version": 5,

--- a/configs/vulnerability.json
+++ b/configs/vulnerability.json
@@ -5,7 +5,7 @@
       "description": "Perform any available operation against any Vulnerability resource.",
       "system": true,
       "platform_default": true,
-      "version": 5,
+      "version": 6,
       "access": [
         {
           "permission": "vulnerability:*:*"


### PR DESCRIPTION
_**Note:** these changes will need to be moved to prod in isolation, as to not move things from CI/QA to prod yet. We'll need a PR into the `prod` branch for this specifically._ 

The following apps' platform default role names and descriptions have been updated
based on a change from the business and UX (https://projects.engineering.redhat.com/browse/RHCLOUD-4963):

- compliance
- drift
- insights
- ~patch~ _(we'll need to add the `patch` change in another PR, since it can't go to prod yet)_
- remediations
- vulnerability