### PR TITLE
Another change to the Patch role name based on marketing

### DIFF
--- a/configs/patch.json
+++ b/configs/patch.json
@@ -1,8 +1,8 @@
 {
   "roles": [
     {
-      "name": "System patch manager administrator",
-      "description": "Perform any available operation against any System Patch Manager resource.",
+      "name": "Patch administrator",
+      "description": "Perform any available operation against any Patch resource.",
       "system": true,
       "platform_default": true,
       "version": 3,


### PR DESCRIPTION
**Note:** will need to remove the old/existing `platform_default` for `System patch manager administrator` in CI and QA.