### PR TITLE
Revert "Remove patch from being promoted"

### DIFF
--- a/configs/patch.json
+++ b/configs/patch.json
@@ -1,0 +1,16 @@
+{
+  "roles": [
+    {
+      "name": "Patch administrator",
+      "description": "Perform any available operation against any Patch resource.",
+      "system": true,
+      "platform_default": true,
+      "version": 3,
+      "access": [
+        {
+          "permission": "patch:*:*"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This reverts commit c06dcaa7e94bdb4eb29ac4464055f5f166ffae06, effectively adding `patch` config back in to be promoted to `prod`, as it already exists in `qa` and `master`.

cc: @semtexzv 