### PR TITLE
Add platform default roles for policies (prod)

### DIFF
--- a/configs/policies.json
+++ b/configs/policies.json
@@ -1,0 +1,16 @@
+{
+    "roles": [
+        {
+            "name": "Policies Access",
+            "description": "An all access role which grants read and write permissions.",
+            "system": true,
+            "platform_default": true,
+            "version": 2,
+            "access": [
+                {
+                    "permission": "policies:*:*"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This is a cherry-pick of f12fa7da0c9763b3ef78ac2bd649df4e4421777d from #43

---

1. Policies team is renaming Custom Policies to Policies.

2. Add this role back and will push all the way from CI to PROD.