### PR TITLE
Add MA default role and update policies name/description

### DIFF
--- a/configs/migration_analytics.json
+++ b/configs/migration_analytics.json
@@ -1,0 +1,16 @@
+{
+  "roles": [
+    {
+      "name": "Migration Analytics administrator",
+      "description": "Perform any available operation against any Migration Analytics resource.",
+      "system": true,
+      "platform_default": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "migration-analytics:*:*"
+        }
+      ]
+    }
+  ]
+}

--- a/configs/policies.json
+++ b/configs/policies.json
@@ -1,16 +1,16 @@
 {
-    "roles": [
+  "roles": [
+    {
+      "name": "Policies administrator",
+      "description": "Perform any available operation against any Policies resource.",
+      "system": true,
+      "platform_default": true,
+      "version": 3,
+      "access": [
         {
-            "name": "Policies Access",
-            "description": "An all access role which grants read and write permissions.",
-            "system": true,
-            "platform_default": true,
-            "version": 3,
-            "access": [
-                {
-                    "permission": "policies:*:*"
-                }
-            ]
+          "permission": "policies:*:*"
         }
-    ]
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
The policies default role name and description needs to be updated. Since roles
are seeded unique based on name, this will effectively create a new role in existing
schemas. New schemas will be created with only the newly named role.

The old roles (based on name) will need to be deleted in CI/QA and prod once
the new config roles up.

The migration analytics role also currently exists in CI/QA but was removed in https://github.com/RedHatInsights/rbac-config/pull/23
This adds the role back in and updates the name and description.

Similarly, the old roles (based on the old name) will need to be deleted in CI and
QA, but MA is not yet in prod.