### PR TITLE
Added new permission catalog:tenant:update

### DIFF
--- a/configs/catalog.json
+++ b/configs/catalog.json
@@ -238,14 +238,17 @@
           ]
         },
         {
-          "permission": "catalog:tenant:update"
+          "permission": "catalog:tenants:update"
+        },
+        {
+          "permission": "catalog:tenants:read"
         }
       ]
     },
     {
       "name": "Catalog User",
       "system": true,
-      "version": 7,
+      "version": 8,
       "description": "A catalog user roles grants read and order permissions",
       "platform_default": true,
       "access": [
@@ -380,6 +383,9 @@
               }
             }
           ]
+        },
+        {
+          "permission": "catalog:tenants:read"
         }
       ]
     }

--- a/configs/catalog.json
+++ b/configs/catalog.json
@@ -3,7 +3,7 @@
     {
       "name": "Catalog Administrator",
       "system": true,
-      "version": 5,
+      "version": 6,
       "description": "A catalog administrator roles grants create,read,update, delete and order permissions",
       "access": [
         {
@@ -236,6 +236,9 @@
               }
             }
           ]
+        },
+        {
+          "permission": "catalog:tenant:update"
         }
       ]
     },


### PR DESCRIPTION
This allows us to do Tenant Settings and Seeding on
the Catalog Side. Currently those actions are checking
for Catalog Administrator Role.