### PR TITLE
Add system role for remediations (prod)

### DIFF
--- a/configs/remediations.json
+++ b/configs/remediations.json
@@ -1,6 +1,18 @@
 {
   "roles": [
     {
+      "name": "Remediations administrator",
+      "description": "Perform any available operation against any Remediations resource",
+      "system": true,
+      "platform_default": false,
+      "version": 2,
+      "access": [
+        {
+          "permission": "remediations:*:*"
+        }
+      ]
+    },  
+    {
       "name": "Remediations user",
       "description": "Perform create, view, update, delete operations against any Remediations resource.",
       "system": true,


### PR DESCRIPTION
Per @astrozzc:
>Remediations have created this role for some tenant.
Those ones have default version 1. Here the version is
set to 2, which will trigger the update when seeding.

This moves the system role to prod