### PR TITLE
Update the cloud cost viewer role to have org unit permissions

### DIFF
--- a/configs/cost-management.json
+++ b/configs/cost-management.json
@@ -16,14 +16,6 @@
             "permission": "cost-management:rate:*"
         }]
     }, {
-        "name": "Cost Price List Viewer",
-        "description": "A cost management role that grants read permissions on price list rates.",
-        "system": true,
-        "version": 2,
-        "access": [{
-            "permission": "cost-management:rate:read"
-        }]
-    }, {
         "name": "Cost Cloud Viewer",
         "description": "A cost management role that grants read permissions on cost reports related to cloud sources.",
         "system": true,
@@ -31,8 +23,10 @@
         "access": [{
             "permission": "cost-management:aws.account:*"
         }, {
+            "permission": "cost-management:aws.organizational_unit:*"
+        }, {
             "permission": "cost-management:azure.subscription_guid:*"
-           }]
+        }]
     }, {
         "name": "Cost OpenShift Viewer",
         "description": "A cost management role that grants read permissions on cost reports related to OpenShift sources.",

--- a/configs/cost-management.json
+++ b/configs/cost-management.json
@@ -16,6 +16,14 @@
             "permission": "cost-management:rate:*"
         }]
     }, {
+        "name": "Cost Price List Viewer",
+        "description": "A cost management role that grants read permissions on price list rates.",
+        "system": true,
+        "version": 2,
+        "access": [{
+            "permission": "cost-management:rate:read"
+        }]
+    }, {
         "name": "Cost Cloud Viewer",
         "description": "A cost management role that grants read permissions on cost reports related to cloud sources.",
         "system": true,


### PR DESCRIPTION
Update the cloud cost viewer role so that it has permission to see all org units. 