### PR TITLE
Bump Automation Analytics role versions

### DIFF
--- a/configs/roles/automation-analytics.json
+++ b/configs/roles/automation-analytics.json
@@ -5,7 +5,7 @@
       "description": "An Automation Analytics Administrator role that grants ALL permissions.",
       "system": true,
       "platform_default": false,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "automation-analytics:*:*"
@@ -17,7 +17,7 @@
       "description": "An Automation Analytics Editor role that grants read-write permissions.",
       "system": true,
       "platform_default": false,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "automation-analytics:*:read"
@@ -32,7 +32,7 @@
       "description": "An Automation Analytics Viewer role that grants read permissions.",
       "system": true,
       "platform_default": false,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "automation-analytics:*:read"


### PR DESCRIPTION
An issue with role seeding prevented the permissions from being attributed to the
new Automation Analytics roles from #75.

This bumps the version, to rerun access/permission creation for these roles based
on the new fix [1] in RBAC.

[1] https://github.com/RedHatInsights/insights-rbac/pull/317