### PR TITLE
Add inventory read permissions to App Admin roles

### DIFF
--- a/configs/roles/compliance.json
+++ b/configs/roles/compliance.json
@@ -8,7 +8,8 @@
       "version": 6,
       "access": [
         {
-          "permission": "compliance:*:*"
+          "permission": "compliance:*:*",
+          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/roles/drift.json
+++ b/configs/roles/drift.json
@@ -8,7 +8,8 @@
       "version": 6,
       "access": [
         {
-          "permission": "drift:*:*"
+          "permission": "drift:*:*",
+          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/roles/insights.json
+++ b/configs/roles/insights.json
@@ -9,7 +9,8 @@
       "version": 7,
       "access": [
         {
-          "permission": "advisor:*:*"
+          "permission": "advisor:*:*",
+          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/roles/patch.json
+++ b/configs/roles/patch.json
@@ -8,7 +8,8 @@
       "version": 3,
       "access": [
         {
-          "permission": "patch:*:*"
+          "permission": "patch:*:*",
+          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/roles/policies.json
+++ b/configs/roles/policies.json
@@ -8,7 +8,8 @@
       "version": 3,
       "access": [
         {
-          "permission": "policies:*:*"
+          "permission": "policies:*:*",
+          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/roles/remediations.json
+++ b/configs/roles/remediations.json
@@ -8,10 +8,11 @@
       "version": 2,
       "access": [
         {
-          "permission": "remediations:*:*"
+          "permission": "remediations:*:*",
+          "permission": "inventory:*:read"
         }
       ]
-    },  
+    },
     {
       "name": "Remediations user",
       "description": "Perform create, view, update, delete operations against any Remediations resource.",

--- a/configs/roles/subscriptions.json
+++ b/configs/roles/subscriptions.json
@@ -8,7 +8,8 @@
       "version": 2,
       "access": [
         {
-          "permission": "subscriptions:*:*"
+          "permission": "subscriptions:*:*",
+          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/roles/vulnerability.json
+++ b/configs/roles/vulnerability.json
@@ -8,7 +8,8 @@
       "version": 6,
       "access": [
         {
-          "permission": "vulnerability:*:*"
+          "permission": "vulnerability:*:*",
+          "permission": "inventory:*:read"
         }
       ]
     }


### PR DESCRIPTION
Inventory read permissions are now a thing. Adding this permission to admin Roles
for apps that have Inventory views and call /api/inventory to draw them.

Without this, a customer would see screens like this: https://marvelapp.com/prototype/f3274de/screen/72596828

Note: we will still have scenarios where customers see ^ so we still need to do ^
Because custom roles can let you setup folks w/o those permissions.