### PR TITLE
Add read-only access role

### DIFF
--- a/configs/roles/read-only.json
+++ b/configs/roles/read-only.json
@@ -1,0 +1,81 @@
+{
+  "roles": [
+    {
+      "name": "Read-only access",
+      "system": true,
+      "version": 2,
+      "description": "A role that grants read permissions.",
+      "access": [
+        {
+          "permission": "advisor:weekly-email:read"
+        },
+        {
+          "permission": "advisor:recommendation-results:read"
+        },
+        {
+          "permission": "advisor:exports:read"
+        },
+        {
+          "permission": "approval:templates:read"
+        },
+        {
+          "permission": "approval:workflows:read"
+        },
+        {
+          "permission": "approval:requests:read"
+        },
+        {
+          "permission": "approval:actions:read"
+        },
+        {
+          "permission": "automation-analytics:*:read"
+        },
+        {
+          "permission": "catalog:approval_requests:read"
+        },
+        {
+          "permission": "catalog:orders:read"
+        },
+        {
+          "permission": "catalog:order_items:read"
+        },
+        {
+          "permission": "catalog:order_processes:read"
+        },
+        {
+          "permission": "catalog:portfolios:read"
+        },
+        {
+          "permission": "catalog:portfolio_items:read"
+        },
+        {
+          "permission": "catalog:progress_messages:read"
+        },
+        {
+          "permission": "catalog:tenants:read"
+        },
+        {
+          "permission": "drift:comparisons:read"
+        },
+        {
+          "permission": "drift:baselines:read"
+        },
+        {
+          "permission": "inventory:*:read"
+        },
+        {
+          "permission": "notifications:notifications:read"
+        },
+        {
+          "permission": "policies:policies:read"
+        },
+        {
+          "permission": "remediations:remediation:read"
+        },
+        {
+          "permission": "vulnerability:*:read"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This role grants read-only access permission, which could be used
for TAMs to access customers account.

JIRA: https://issues.redhat.com/browse/RHCLOUD-8987

Advisor: disable-recommendations does not have read permission

Compliance: no read permission defined

Cost-managment: the permission stays in CI, their permission definition is different in QA and prod, have to wait for them to promote their changes to QA and prod

migration_analytics: no read permission defined

patch: no read permission defined

subscriptions: no read permission defined