### PR TITLE
Set Automation Analytics Editor role to be the platform default

### DIFF
--- a/configs/roles/automation-analytics.json
+++ b/configs/roles/automation-analytics.json
@@ -16,8 +16,8 @@
       "name": "Automation Analytics Editor",
       "description": "An Automation Analytics Editor role that grants read-write permissions.",
       "system": true,
-      "platform_default": false,
-      "version": 3,
+      "platform_default": true,
+      "version": 4,
       "access": [
         {
           "permission": "automation-analytics:*:read"


### PR DESCRIPTION
Set Automation Analytics Editor role to be the platform default