### PR TITLE
Setup push action for `master` to convert JSON to ConfigMaps

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+    branches:
+      - master
+name: Config Conversion
+jobs:
+  convert_config:
+    name: Convert Config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Converting config to configmaps
+        uses: RedHatInsights/rbac-config-actions@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch_name: master


### PR DESCRIPTION
This will use the following action: https://github.com/RedHatInsights/rbac-config-actions
to convert over JSON config into ConfigMaps when a new commit is pushed to `master`,
and will push a commit with the file changes up based on the output of the action.

By default, these will reside in in `_private/configmaps/*` - note that we'll need to update the 
action once we namespace the config, but this will help us test the integration until then.