### PR TITLE
Create a PR on merge to `master`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,4 +13,8 @@ jobs:
         uses: RedHatInsights/rbac-config-actions@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch_name: master
+          branch_name: configmaps
+      - name: Create a PR with Config Changes
+        run: hub pull-request --no-edit -b master -h configmaps
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When a commit is pushed/merged into `master`, we'll create a PR based on the outcome
of what's pushed to the `configmaps` branch, which will be the generated ConfigMaps
from our `rbac-config-actions` run.

We have to do this currently, because our `master` branch requires PR review for
any commits, so we can't directly commit from our action to `master`.