### PR TITLE
Add hsp permissions

### DIFF
--- a/configs/ci/permissions/drift.json
+++ b/configs/ci/permissions/drift.json
@@ -16,5 +16,10 @@
         {
             "verb": "write"
         }
+    ],
+    "historical-system-profiles": [
+        {
+            "verb": "read"
+        }
     ]
 }


### PR DESCRIPTION
Add permissions for historical-system-profiles to Drift in addition to the baselines and comparisons permissions.