### PR TITLE
Bump cost role version to pickup new permissions

### DIFF
--- a/configs/ci/roles/cost-management.json
+++ b/configs/ci/roles/cost-management.json
@@ -27,7 +27,7 @@
         "name": "Cost Cloud Viewer",
         "description": "A cost management role that grants read permissions on cost reports related to cloud sources.",
         "system": true,
-        "version": 4,
+        "version": 5,
         "access": [{
             "permission": "cost-management:aws.account:*"
         }, {

--- a/configs/qa/roles/cost-management.json
+++ b/configs/qa/roles/cost-management.json
@@ -27,7 +27,7 @@
         "name": "Cost Cloud Viewer",
         "description": "A cost management role that grants read permissions on cost reports related to cloud sources.",
         "system": true,
-        "version": 4,
+        "version": 5,
         "access": [{
             "permission": "cost-management:aws.account:*"
         }, {


### PR DESCRIPTION
For the role changes in #130 to be picked up, we need to bump the role version.