### PR TITLE
Add hsp permissions to drift qa env

### DIFF
--- a/configs/qa/permissions/drift.json
+++ b/configs/qa/permissions/drift.json
@@ -16,5 +16,10 @@
         {
             "verb": "write"
         }
+    ],
+    "historical-system-profiles": [
+	{
+	    "verb": "read"
+	}
     ]
 }


### PR DESCRIPTION
Our previous PR adding this new permission to ci worked,
now propagating to qa environment.