### PR TITLE
Add hsp permissions to drift prod env

### DIFF
--- a/configs/prod/permissions/drift.json
+++ b/configs/prod/permissions/drift.json
@@ -16,5 +16,10 @@
         {
             "verb": "write"
         }
+    ],
+    "historical-system-profiles": [
+	{
+	    "verb": "read"
+	}
     ]
 }


### PR DESCRIPTION
We're ready to go to prod, so we've opened the stage PR (https://github.com/RedHatInsights/rbac-config/pull/150), and as soon as it's done, then here is the prod one to follow it.
Tracked here:
https://issues.redhat.com/browse/RHCLOUD-12719