### PR TITLE
Bump Cost Cloud Viewer role in stage/prod

### DIFF
--- a/configs/prod/roles/cost-management.json
+++ b/configs/prod/roles/cost-management.json
@@ -27,7 +27,7 @@
         "name": "Cost Cloud Viewer",
         "description": "A cost management role that grants read permissions on cost reports related to cloud sources.",
         "system": true,
-        "version": 4,
+        "version": 5,
         "access": [{
             "permission": "cost-management:aws.account:*"
         }, {

--- a/configs/stage/roles/cost-management.json
+++ b/configs/stage/roles/cost-management.json
@@ -27,7 +27,7 @@
         "name": "Cost Cloud Viewer",
         "description": "A cost management role that grants read permissions on cost reports related to cloud sources.",
         "system": true,
-        "version": 4,
+        "version": 5,
         "access": [{
             "permission": "cost-management:aws.account:*"
         }, {


### PR DESCRIPTION
PR https://github.com/RedHatInsights/rbac-config/pull/112 added `gcp` permissions
to the Cost Cloud Viewer role, but didn't bump the version, so the changes were not
applied in stage or production.

They are fine in CI and QA because of https://github.com/RedHatInsights/rbac-config/pull/130
which added the IBM permission to the roles in those environments and bumped the version.