### PR TITLE
Add fine-grained resources for Subscriptions app

### DIFF
--- a/configs/ci/permissions/subscriptions.json
+++ b/configs/ci/permissions/subscriptions.json
@@ -1,4 +1,17 @@
 {
+    "reports": [
+        {
+            "verb": "read"
+        }
+    ],
+    "manifests": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        }
+    ],
     "*": [
         {
             "verb": "*"

--- a/configs/ci/roles/subscriptions.json
+++ b/configs/ci/roles/subscriptions.json
@@ -2,13 +2,32 @@
   "roles": [
     {
       "name": "Subscription Watch administrator",
-      "description": "Perform any available operation against any Subscription Watch resource.",
+      "display_name": "Subscriptions administrator",
+      "description": "Perform any available operation against any Subscriptions resource.",
       "system": true,
-      "platform_default": true,
-      "version": 4,
+      "platform_default": false,
+      "version": 5,
       "access": [
         {
           "permission": "subscriptions:*:*"
+        },
+        {
+          "permission": "inventory:*:read"
+        }
+      ]
+    },
+    {
+      "name": "Subscriptions user",
+      "description": "View any Subscriptions resource.",
+      "system": true,
+      "platform_default": true,
+      "version": 1,
+      "access": [
+        {
+          "permission": "subscriptions:reports:read"
+        },
+        {
+          "permission": "subscriptions:manifests:read"
         },
         {
           "permission": "inventory:*:read"

--- a/configs/qa/permissions/subscriptions.json
+++ b/configs/qa/permissions/subscriptions.json
@@ -1,4 +1,17 @@
 {
+    "reports": [
+        {
+            "verb": "read"
+        }
+    ],
+    "manifests": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        }
+    ],
     "*": [
         {
             "verb": "*"

--- a/configs/qa/roles/subscriptions.json
+++ b/configs/qa/roles/subscriptions.json
@@ -2,13 +2,32 @@
   "roles": [
     {
       "name": "Subscription Watch administrator",
-      "description": "Perform any available operation against any Subscription Watch resource.",
+      "display_name": "Subscriptions administrator",
+      "description": "Perform any available operation against any Subscriptions resource.",
       "system": true,
-      "platform_default": true,
-      "version": 4,
+      "platform_default": false,
+      "version": 5,
       "access": [
         {
           "permission": "subscriptions:*:*"
+        },
+        {
+          "permission": "inventory:*:read"
+        }
+      ]
+    },
+    {
+      "name": "Subscriptions user",
+      "description": "View any Subscriptions resource.",
+      "system": true,
+      "platform_default": true,
+      "version": 1,
+      "access": [
+        {
+          "permission": "subscriptions:reports:read"
+        },
+        {
+          "permission": "subscriptions:manifests:read"
         },
         {
           "permission": "inventory:*:read"

--- a/configs/stage/permissions/subscriptions.json
+++ b/configs/stage/permissions/subscriptions.json
@@ -1,4 +1,17 @@
 {
+    "reports": [
+        {
+            "verb": "read"
+        }
+    ],
+    "manifests": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        }
+    ],
     "*": [
         {
             "verb": "*"

--- a/configs/stage/roles/subscriptions.json
+++ b/configs/stage/roles/subscriptions.json
@@ -2,13 +2,32 @@
   "roles": [
     {
       "name": "Subscription Watch administrator",
-      "description": "Perform any available operation against any Subscription Watch resource.",
+      "display_name": "Subscriptions administrator",
+      "description": "Perform any available operation against any Subscriptions resource.",
       "system": true,
-      "platform_default": true,
-      "version": 4,
+      "platform_default": false,
+      "version": 5,
       "access": [
         {
           "permission": "subscriptions:*:*"
+        },
+        {
+          "permission": "inventory:*:read"
+        }
+      ]
+    },
+    {
+      "name": "Subscriptions user",
+      "description": "View any Subscriptions resource.",
+      "system": true,
+      "platform_default": true,
+      "version": 1,
+      "access": [
+        {
+          "permission": "subscriptions:reports:read"
+        },
+        {
+          "permission": "subscriptions:manifests:read"
         },
         {
           "permission": "inventory:*:read"


### PR DESCRIPTION
Adds these new permissions in ci/qa/stage:
- Read Reports
- Read/Write Manifests

Makes these role changes:
- Renames "Subscription Watch administrator" to "Subscriptions administrator" with read/write permissions and makes it non-default
- Adds a "Subscription Watch user" role with view-only permissions