### PR TITLE
Update 'subscriptions' admin role display name

### DIFF
--- a/configs/ci/roles/subscriptions.json
+++ b/configs/ci/roles/subscriptions.json
@@ -3,7 +3,7 @@
     {
       "name": "Subscription Watch administrator",
       "display_name": "Subscriptions administrator",
-      "description": "Perform any available operation against any Subscription Watch resource.",
+      "description": "Perform any available operation against any Subscriptions resource.",
       "system": true,
       "platform_default": true,
       "version": 5,

--- a/configs/ci/roles/subscriptions.json
+++ b/configs/ci/roles/subscriptions.json
@@ -2,10 +2,11 @@
   "roles": [
     {
       "name": "Subscription Watch administrator",
+      "display_name": "Subscriptions administrator",
       "description": "Perform any available operation against any Subscription Watch resource.",
       "system": true,
       "platform_default": true,
-      "version": 4,
+      "version": 5,
       "access": [
         {
           "permission": "subscriptions:*:*"

--- a/configs/prod/roles/subscriptions.json
+++ b/configs/prod/roles/subscriptions.json
@@ -3,7 +3,7 @@
     {
       "name": "Subscription Watch administrator",
       "display_name": "Subscriptions administrator",
-      "description": "Perform any available operation against any Subscription Watch resource.",
+      "description": "Perform any available operation against any Subscriptions resource.",
       "system": true,
       "platform_default": true,
       "version": 5,

--- a/configs/prod/roles/subscriptions.json
+++ b/configs/prod/roles/subscriptions.json
@@ -2,10 +2,11 @@
   "roles": [
     {
       "name": "Subscription Watch administrator",
+      "display_name": "Subscriptions administrator",
       "description": "Perform any available operation against any Subscription Watch resource.",
       "system": true,
       "platform_default": true,
-      "version": 4,
+      "version": 5,
       "access": [
         {
           "permission": "subscriptions:*:*"

--- a/configs/qa/roles/subscriptions.json
+++ b/configs/qa/roles/subscriptions.json
@@ -3,7 +3,7 @@
     {
       "name": "Subscription Watch administrator",
       "display_name": "Subscriptions administrator",
-      "description": "Perform any available operation against any Subscription Watch resource.",
+      "description": "Perform any available operation against any Subscriptions resource.",
       "system": true,
       "platform_default": true,
       "version": 5,

--- a/configs/qa/roles/subscriptions.json
+++ b/configs/qa/roles/subscriptions.json
@@ -2,10 +2,11 @@
   "roles": [
     {
       "name": "Subscription Watch administrator",
+      "display_name": "Subscriptions administrator",
       "description": "Perform any available operation against any Subscription Watch resource.",
       "system": true,
       "platform_default": true,
-      "version": 4,
+      "version": 5,
       "access": [
         {
           "permission": "subscriptions:*:*"

--- a/configs/stage/roles/subscriptions.json
+++ b/configs/stage/roles/subscriptions.json
@@ -3,7 +3,7 @@
     {
       "name": "Subscription Watch administrator",
       "display_name": "Subscriptions administrator",
-      "description": "Perform any available operation against any Subscription Watch resource.",
+      "description": "Perform any available operation against any Subscriptions resource.",
       "system": true,
       "platform_default": true,
       "version": 5,

--- a/configs/stage/roles/subscriptions.json
+++ b/configs/stage/roles/subscriptions.json
@@ -2,10 +2,11 @@
   "roles": [
     {
       "name": "Subscription Watch administrator",
+      "display_name": "Subscriptions administrator",
       "description": "Perform any available operation against any Subscription Watch resource.",
       "system": true,
       "platform_default": true,
-      "version": 4,
+      "version": 5,
       "access": [
         {
           "permission": "subscriptions:*:*"


### PR DESCRIPTION
This adds a `display_name` to update `Subscription Watch administrator` to
`Subscription administrator` and bumps the version so seeds pick the changes up.

This will be the new value displayed in the UI.