### PR TITLE
Config manager stage prod

### DIFF
--- a/configs/prod/permissions/config-manager.json
+++ b/configs/prod/permissions/config-manager.json
@@ -1,0 +1,15 @@
+{
+    "state": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        }
+    ],
+    "state-changes": [
+        {
+            "verb": "read"
+        }
+    ]
+}

--- a/configs/prod/roles/config-manager.json
+++ b/configs/prod/roles/config-manager.json
@@ -1,0 +1,68 @@
+{
+    "roles": [
+      {
+        "name": "RHC Administrator",
+        "description": "Perform any operations on the service enablement dashboard",
+        "system": true,
+        "platform_default": false,
+        "version": 2,
+        "access": [
+          {
+            "permission": "config-manager:state:read"
+          },
+          {
+            "permission": "config-manager:state:write"
+          },
+          {
+            "permission": "config-manager:state-changes:read"
+          },
+          {
+            "permission": "inventory:*:read"
+          },
+          {
+            "permission": "playbook-dispatcher:run:read",
+            "resourceDefinitions": [
+              {
+                "attributeFilter": {
+                  "key": "service",
+                  "operation": "equal",
+                  "value": "config_manager"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "RHC Viewer",
+        "description": "Can view the service enablement dashboard",
+        "system": true,
+        "platform_default": true,
+        "version": 2,
+        "access": [
+          {
+            "permission": "config-manager:state:read"
+          },
+          {
+            "permission": "config-manager:state-changes:read"
+          },
+          {
+            "permission": "inventory:*:read"
+          },
+          {
+            "permission": "playbook-dispatcher:run:read",
+            "resourceDefinitions": [
+              {
+                "attributeFilter": {
+                  "key": "service",
+                  "operation": "equal",
+                  "value": "config_manager"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/configs/prod/roles/config-manager.json
+++ b/configs/prod/roles/config-manager.json
@@ -1,68 +1,67 @@
 {
-    "roles": [
-      {
-        "name": "RHC Administrator",
-        "description": "Perform any operations on the service enablement dashboard",
-        "system": true,
-        "platform_default": false,
-        "version": 2,
-        "access": [
-          {
-            "permission": "config-manager:state:read"
-          },
-          {
-            "permission": "config-manager:state:write"
-          },
-          {
-            "permission": "config-manager:state-changes:read"
-          },
-          {
-            "permission": "inventory:*:read"
-          },
-          {
-            "permission": "playbook-dispatcher:run:read",
-            "resourceDefinitions": [
-              {
-                "attributeFilter": {
-                  "key": "service",
-                  "operation": "equal",
-                  "value": "config_manager"
-                }
+  "roles": [
+    {
+      "name": "RHC Administrator",
+      "description": "Perform any operations on the service enablement dashboard",
+      "system": true,
+      "platform_default": false,
+      "version": 2,
+      "access": [
+        {
+          "permission": "config-manager:state:read"
+        },
+        {
+          "permission": "config-manager:state:write"
+        },
+        {
+          "permission": "config-manager:state-changes:read"
+        },
+        {
+          "permission": "inventory:*:read"
+        },
+        {
+          "permission": "playbook-dispatcher:run:read",
+          "resourceDefinitions": [
+            {
+              "attributeFilter": {
+                "key": "service",
+                "operation": "equal",
+                "value": "config_manager"
               }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "RHC Viewer",
-        "description": "Can view the service enablement dashboard",
-        "system": true,
-        "platform_default": true,
-        "version": 2,
-        "access": [
-          {
-            "permission": "config-manager:state:read"
-          },
-          {
-            "permission": "config-manager:state-changes:read"
-          },
-          {
-            "permission": "inventory:*:read"
-          },
-          {
-            "permission": "playbook-dispatcher:run:read",
-            "resourceDefinitions": [
-              {
-                "attributeFilter": {
-                  "key": "service",
-                  "operation": "equal",
-                  "value": "config_manager"
-                }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "RHC Viewer",
+      "description": "Can view the service enablement dashboard",
+      "system": true,
+      "platform_default": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "config-manager:state:read"
+        },
+        {
+          "permission": "config-manager:state-changes:read"
+        },
+        {
+          "permission": "inventory:*:read"
+        },
+        {
+          "permission": "playbook-dispatcher:run:read",
+          "resourceDefinitions": [
+            {
+              "attributeFilter": {
+                "key": "service",
+                "operation": "equal",
+                "value": "config_manager"
               }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-  
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/configs/stage/permissions/config-manager.json
+++ b/configs/stage/permissions/config-manager.json
@@ -1,0 +1,15 @@
+{
+    "state": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        }
+    ],
+    "state-changes": [
+        {
+            "verb": "read"
+        }
+    ]
+}

--- a/configs/stage/roles/config-manager.json
+++ b/configs/stage/roles/config-manager.json
@@ -1,0 +1,68 @@
+{
+    "roles": [
+      {
+        "name": "RHC Administrator",
+        "description": "Perform any operations on the service enablement dashboard",
+        "system": true,
+        "platform_default": false,
+        "version": 2,
+        "access": [
+          {
+            "permission": "config-manager:state:read"
+          },
+          {
+            "permission": "config-manager:state:write"
+          },
+          {
+            "permission": "config-manager:state-changes:read"
+          },
+          {
+            "permission": "inventory:*:read"
+          },
+          {
+            "permission": "playbook-dispatcher:run:read",
+            "resourceDefinitions": [
+              {
+                "attributeFilter": {
+                  "key": "service",
+                  "operation": "equal",
+                  "value": "config_manager"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "RHC Viewer",
+        "description": "Can view the service enablement dashboard",
+        "system": true,
+        "platform_default": true,
+        "version": 2,
+        "access": [
+          {
+            "permission": "config-manager:state:read"
+          },
+          {
+            "permission": "config-manager:state-changes:read"
+          },
+          {
+            "permission": "inventory:*:read"
+          },
+          {
+            "permission": "playbook-dispatcher:run:read",
+            "resourceDefinitions": [
+              {
+                "attributeFilter": {
+                  "key": "service",
+                  "operation": "equal",
+                  "value": "config_manager"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/configs/stage/roles/config-manager.json
+++ b/configs/stage/roles/config-manager.json
@@ -1,68 +1,67 @@
 {
-    "roles": [
-      {
-        "name": "RHC Administrator",
-        "description": "Perform any operations on the service enablement dashboard",
-        "system": true,
-        "platform_default": false,
-        "version": 2,
-        "access": [
-          {
-            "permission": "config-manager:state:read"
-          },
-          {
-            "permission": "config-manager:state:write"
-          },
-          {
-            "permission": "config-manager:state-changes:read"
-          },
-          {
-            "permission": "inventory:*:read"
-          },
-          {
-            "permission": "playbook-dispatcher:run:read",
-            "resourceDefinitions": [
-              {
-                "attributeFilter": {
-                  "key": "service",
-                  "operation": "equal",
-                  "value": "config_manager"
-                }
+  "roles": [
+    {
+      "name": "RHC Administrator",
+      "description": "Perform any operations on the service enablement dashboard",
+      "system": true,
+      "platform_default": false,
+      "version": 2,
+      "access": [
+        {
+          "permission": "config-manager:state:read"
+        },
+        {
+          "permission": "config-manager:state:write"
+        },
+        {
+          "permission": "config-manager:state-changes:read"
+        },
+        {
+          "permission": "inventory:*:read"
+        },
+        {
+          "permission": "playbook-dispatcher:run:read",
+          "resourceDefinitions": [
+            {
+              "attributeFilter": {
+                "key": "service",
+                "operation": "equal",
+                "value": "config_manager"
               }
-            ]
-          }
-        ]
-      },
-      {
-        "name": "RHC Viewer",
-        "description": "Can view the service enablement dashboard",
-        "system": true,
-        "platform_default": true,
-        "version": 2,
-        "access": [
-          {
-            "permission": "config-manager:state:read"
-          },
-          {
-            "permission": "config-manager:state-changes:read"
-          },
-          {
-            "permission": "inventory:*:read"
-          },
-          {
-            "permission": "playbook-dispatcher:run:read",
-            "resourceDefinitions": [
-              {
-                "attributeFilter": {
-                  "key": "service",
-                  "operation": "equal",
-                  "value": "config_manager"
-                }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "RHC Viewer",
+      "description": "Can view the service enablement dashboard",
+      "system": true,
+      "platform_default": true,
+      "version": 2,
+      "access": [
+        {
+          "permission": "config-manager:state:read"
+        },
+        {
+          "permission": "config-manager:state-changes:read"
+        },
+        {
+          "permission": "inventory:*:read"
+        },
+        {
+          "permission": "playbook-dispatcher:run:read",
+          "resourceDefinitions": [
+            {
+              "attributeFilter": {
+                "key": "service",
+                "operation": "equal",
+                "value": "config_manager"
               }
-            ]
-          }
-        ]
-      }
-    ]
-  }
-  
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
@coderbydesign These roles are currently working in CI/QA and I'd like to get them added to Stage/Prod. Is it okay to keep them as version 2 or should I update all config-manager roles to version 3 (no changes, just new environments)?