### PR TITLE
Update `config-manager` role names

### DIFF
--- a/configs/ci/roles/config-manager.json
+++ b/configs/ci/roles/config-manager.json
@@ -2,10 +2,11 @@
   "roles": [
     {
       "name": "RHC Administrator",
+      "display_name": "Red Hat connector administrator",
       "description": "Perform any operations on the service enablement dashboard",
       "system": true,
       "platform_default": false,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "config-manager:state:read"
@@ -35,10 +36,11 @@
     },
     {
       "name": "RHC Viewer",
+      "display_name": "Red Hat connector viewer",
       "description": "Can view the service enablement dashboard",
       "system": true,
       "platform_default": true,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "config-manager:state:read"

--- a/configs/prod/roles/config-manager.json
+++ b/configs/prod/roles/config-manager.json
@@ -2,10 +2,11 @@
   "roles": [
     {
       "name": "RHC Administrator",
+      "display_name": "Red Hat connector administrator",
       "description": "Perform any operations on the service enablement dashboard",
       "system": true,
       "platform_default": false,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "config-manager:state:read"
@@ -35,10 +36,11 @@
     },
     {
       "name": "RHC Viewer",
+      "display_name": "Red Hat connector viewer",
       "description": "Can view the service enablement dashboard",
       "system": true,
       "platform_default": true,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "config-manager:state:read"

--- a/configs/qa/roles/config-manager.json
+++ b/configs/qa/roles/config-manager.json
@@ -2,10 +2,11 @@
   "roles": [
     {
       "name": "RHC Administrator",
+      "display_name": "Red Hat connector administrator",
       "description": "Perform any operations on the service enablement dashboard",
       "system": true,
       "platform_default": false,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "config-manager:state:read"
@@ -35,10 +36,11 @@
     },
     {
       "name": "RHC Viewer",
+      "display_name": "Red Hat connector viewer",
       "description": "Can view the service enablement dashboard",
       "system": true,
       "platform_default": true,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "config-manager:state:read"

--- a/configs/stage/roles/config-manager.json
+++ b/configs/stage/roles/config-manager.json
@@ -2,10 +2,11 @@
   "roles": [
     {
       "name": "RHC Administrator",
+      "display_name": "Red Hat connector administrator",
       "description": "Perform any operations on the service enablement dashboard",
       "system": true,
       "platform_default": false,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "config-manager:state:read"
@@ -35,10 +36,11 @@
     },
     {
       "name": "RHC Viewer",
+      "display_name": "Red Hat connector viewer",
       "description": "Can view the service enablement dashboard",
       "system": true,
       "platform_default": true,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "config-manager:state:read"


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-14973

- Change from "RHC Administrator" to "Red Hat connector administrator"
- Change from "RHC Viewer" to "Red Hat connector viewer"
- Bump versions