### PR TITLE
Subscriptions: rename "write" permission to "manage"

### DIFF
--- a/configs/ci/permissions/subscriptions.json
+++ b/configs/ci/permissions/subscriptions.json
@@ -9,7 +9,7 @@
             "verb": "read"
         },
         {
-            "verb": "write"
+            "verb": "manage"
         }
     ],
     "*": [

--- a/configs/qa/permissions/subscriptions.json
+++ b/configs/qa/permissions/subscriptions.json
@@ -9,7 +9,7 @@
             "verb": "read"
         },
         {
-            "verb": "write"
+            "verb": "manage"
         }
     ],
     "*": [

--- a/configs/stage/permissions/subscriptions.json
+++ b/configs/stage/permissions/subscriptions.json
@@ -9,7 +9,7 @@
             "verb": "read"
         },
         {
-            "verb": "write"
+            "verb": "manage"
         }
     ],
     "*": [

--- a/schemas/permissions.schema
+++ b/schemas/permissions.schema
@@ -18,7 +18,8 @@
               "link",
               "unlink",
               "order",
-              "execute"
+              "execute",
+              "manage"
             ]
           },
           "description": {


### PR DESCRIPTION
After discussing with our PMs, we've decided to rename our `write` permission to `manage` to more clearly indicate that it is inclusive of `read`.