### PR TITLE
promote & edit permissions for vulnerability app

### DIFF
--- a/configs/ci/permissions/vulnerability.json
+++ b/configs/ci/permissions/vulnerability.json
@@ -15,32 +15,27 @@
             "verb": "read"
         }
     ],
-    "cve.business_risk": [
+    "cve.business_risk_and_status": [
         {
             "verb": "write"
         }
     ],
-    "cve.status": [
+    "system.cve.status": [
         {
             "verb": "write"
         }
     ],
-    "cve_system.cve.status": [
-        {
-            "verb": "write"
-        }
-    ],
-    "report": [
+    "advanced_report": [
         {
             "verb": "read"
-        },
-        {
-            "verb": "write"
         }
     ],
-    "system": [
+    "system.opt_out": [
         {
             "verb": "write"
+        },
+        {
+            "verb": "read"
         }
     ]
 }

--- a/configs/qa/permissions/vulnerability.json
+++ b/configs/qa/permissions/vulnerability.json
@@ -15,32 +15,27 @@
             "verb": "read"
         }
     ],
-    "cve.business_risk": [
+    "cve.business_risk_and_status": [
         {
             "verb": "write"
         }
     ],
-    "cve.status": [
+    "system.cve.status": [
         {
             "verb": "write"
         }
     ],
-    "cve_system.cve.status": [
-        {
-            "verb": "write"
-        }
-    ],
-    "report": [
+    "advanced_report": [
         {
             "verb": "read"
-        },
-        {
-            "verb": "write"
         }
     ],
-    "system": [
+    "system.opt_out": [
         {
             "verb": "write"
+        },
+        {
+            "verb": "read"
         }
     ]
 }

--- a/configs/stage/permissions/vulnerability.json
+++ b/configs/stage/permissions/vulnerability.json
@@ -1,7 +1,41 @@
 {
     "*": [
         {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        },
+        {
             "verb": "*"
+        }
+    ],
+    "vulnerability_results": [
+        {
+            "verb": "read"
+        }
+    ],
+    "cve.business_risk_and_status": [
+        {
+            "verb": "write"
+        }
+    ],
+    "system.cve.status": [
+        {
+            "verb": "write"
+        }
+    ],
+    "advanced_report": [
+        {
+            "verb": "read"
+        }
+    ],
+    "system.opt_out": [
+        {
+            "verb": "write"
+        },
+        {
+            "verb": "read"
         }
     ]
 }


### PR DESCRIPTION
Firstly, the permissions needs to be changed according to our RBAC document. As ci/qa is taken as deprecated, promote permissions to stage for further rbac integration in vulnerability.