### PR TITLE
Prod permission and roles for subscriptions app

### DIFF
--- a/configs/prod/permissions/subscriptions.json
+++ b/configs/prod/permissions/subscriptions.json
@@ -1,4 +1,25 @@
 {
+    "reports": [
+        {
+            "verb": "read"
+        }
+    ],
+    "manifests": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        }
+    ],
+    "organization": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        }
+    ],
     "*": [
         {
             "verb": "*"

--- a/configs/prod/roles/subscriptions.json
+++ b/configs/prod/roles/subscriptions.json
@@ -2,13 +2,35 @@
   "roles": [
     {
       "name": "Subscription Watch administrator",
-      "description": "Perform any available operation against any Subscription Watch resource.",
+      "display_name": "Subscriptions administrator",
+      "description": "Perform any available operation against any Subscriptions resource.",
       "system": true,
-      "platform_default": true,
-      "version": 4,
+      "platform_default": false,
+      "version": 5,
       "access": [
         {
           "permission": "subscriptions:*:*"
+        },
+        {
+          "permission": "inventory:*:read"
+        }
+      ]
+    },
+    {
+      "name": "Subscriptions user",
+      "description": "View any Subscriptions resource.",
+      "system": true,
+      "platform_default": true,
+      "version": 1,
+      "access": [
+        {
+          "permission": "subscriptions:reports:read"
+        },
+        {
+          "permission": "subscriptions:manifests:read"
+        },
+        {
+          "permission": "subscriptions:organization:read"
         },
         {
           "permission": "inventory:*:read"


### PR DESCRIPTION
#### Adds these permissions in prod (replicates lower env permissions):

- Read and Write Organization
- Read and Write Manifest
- Read Reports

#### Adds these role changes in prod (replicates lower env roles):

- **Subscription Watch administrator** role 
- **Subscriptions user** role 