### PR TITLE
Bump subscriptions role version in pre-prod

### DIFF
--- a/configs/ci/roles/subscriptions.json
+++ b/configs/ci/roles/subscriptions.json
@@ -21,7 +21,7 @@
       "description": "View any Subscriptions resource.",
       "system": true,
       "platform_default": true,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "subscriptions:reports:read"

--- a/configs/qa/roles/subscriptions.json
+++ b/configs/qa/roles/subscriptions.json
@@ -21,7 +21,7 @@
       "description": "View any Subscriptions resource.",
       "system": true,
       "platform_default": true,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "subscriptions:reports:read"

--- a/configs/stage/roles/subscriptions.json
+++ b/configs/stage/roles/subscriptions.json
@@ -21,7 +21,7 @@
       "description": "View any Subscriptions resource.",
       "system": true,
       "platform_default": true,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "subscriptions:reports:read"


### PR DESCRIPTION
In a previous commit: https://github.com/RedHatInsights/rbac-config/commit/5120938a3770754d849447571d70f1b6c27cfb4b#diff-78fb85dcb6736d099ecd3d31683579418b58c91ec2d297053e167ab6c9be199f
there were role changes but the version was not bumped. This fixes that in pre-prod.

In prod: https://github.com/RedHatInsights/rbac-config/commit/12d887b515256a522dd8679b31d2f8fcc9b3021a#diff-4f307dc98f4f3583574d9a7b1bfcaa811fedc79b4d696f88687a46bdbae3ca2a
they were added at once, so no need to bump the version.