### PR TITLE
Cloud to console for rbac role description

### DIFF
--- a/configs/ci/roles/rbac.json
+++ b/configs/ci/roles/rbac.json
@@ -3,7 +3,7 @@
     {
       "name": "User Access administrator",
       "display_name": "User Access administrator",
-      "description": "Grants a non-org admin full access to configure and manage user access to services hosted on cloud.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
+      "description": "Grants a non-org admin full access to configure and manage user access to services hosted on console.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
       "system": true,
       "platform_default": false,
       "version": 1,

--- a/configs/ci/roles/rbac.json
+++ b/configs/ci/roles/rbac.json
@@ -6,7 +6,7 @@
       "description": "Grants a non-org admin full access to configure and manage user access to services hosted on console.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
       "system": true,
       "platform_default": false,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "rbac:*:*"

--- a/configs/fedramp-prod/roles/rbac.json
+++ b/configs/fedramp-prod/roles/rbac.json
@@ -3,7 +3,7 @@
     {
       "name": "User Access administrator",
       "display_name": "User Access administrator",
-      "description": "Grants a non-org admin full access to configure and manage user access to services hosted on cloud.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
+      "description": "Grants a non-org admin full access to configure and manage user access to services hosted on console.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
       "system": true,
       "platform_default": false,
       "version": 1,

--- a/configs/fedramp-prod/roles/rbac.json
+++ b/configs/fedramp-prod/roles/rbac.json
@@ -6,7 +6,7 @@
       "description": "Grants a non-org admin full access to configure and manage user access to services hosted on console.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
       "system": true,
       "platform_default": false,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "rbac:*:*"

--- a/configs/fedramp-stage/roles/rbac.json
+++ b/configs/fedramp-stage/roles/rbac.json
@@ -3,7 +3,7 @@
     {
       "name": "User Access administrator",
       "display_name": "User Access administrator",
-      "description": "Grants a non-org admin full access to configure and manage user access to services hosted on cloud.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
+      "description": "Grants a non-org admin full access to configure and manage user access to services hosted on console.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
       "system": true,
       "platform_default": false,
       "version": 1,

--- a/configs/fedramp-stage/roles/rbac.json
+++ b/configs/fedramp-stage/roles/rbac.json
@@ -6,7 +6,7 @@
       "description": "Grants a non-org admin full access to configure and manage user access to services hosted on console.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
       "system": true,
       "platform_default": false,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "rbac:*:*"

--- a/configs/prod/roles/rbac.json
+++ b/configs/prod/roles/rbac.json
@@ -3,7 +3,7 @@
     {
       "name": "User Access administrator",
       "display_name": "User Access administrator",
-      "description": "Grants a non-org admin full access to configure and manage user access to services hosted on cloud.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
+      "description": "Grants a non-org admin full access to configure and manage user access to services hosted on console.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
       "system": true,
       "platform_default": false,
       "version": 1,

--- a/configs/prod/roles/rbac.json
+++ b/configs/prod/roles/rbac.json
@@ -6,7 +6,7 @@
       "description": "Grants a non-org admin full access to configure and manage user access to services hosted on console.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
       "system": true,
       "platform_default": false,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "rbac:*:*"

--- a/configs/qa/roles/rbac.json
+++ b/configs/qa/roles/rbac.json
@@ -3,7 +3,7 @@
     {
       "name": "User Access administrator",
       "display_name": "User Access administrator",
-      "description": "Grants a non-org admin full access to configure and manage user access to services hosted on cloud.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
+      "description": "Grants a non-org admin full access to configure and manage user access to services hosted on console.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
       "system": true,
       "platform_default": false,
       "version": 1,

--- a/configs/qa/roles/rbac.json
+++ b/configs/qa/roles/rbac.json
@@ -6,7 +6,7 @@
       "description": "Grants a non-org admin full access to configure and manage user access to services hosted on console.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
       "system": true,
       "platform_default": false,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "rbac:*:*"

--- a/configs/stage/roles/rbac.json
+++ b/configs/stage/roles/rbac.json
@@ -3,7 +3,7 @@
     {
       "name": "User Access administrator",
       "display_name": "User Access administrator",
-      "description": "Grants a non-org admin full access to configure and manage user access to services hosted on cloud.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
+      "description": "Grants a non-org admin full access to configure and manage user access to services hosted on console.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
       "system": true,
       "platform_default": false,
       "version": 1,

--- a/configs/stage/roles/rbac.json
+++ b/configs/stage/roles/rbac.json
@@ -6,7 +6,7 @@
       "description": "Grants a non-org admin full access to configure and manage user access to services hosted on console.redhat.com. This role can only be viewed and assigned by Organization Administrators.",
       "system": true,
       "platform_default": false,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "rbac:*:*"


### PR DESCRIPTION
In the UI, I noticed that the role description used `cloud.redhat.com` which may be confusing for users. 

cc @coderbydesign @wcmitchell @astrozzc 