### PR TITLE
Admin default schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,27 @@ for roles and permissions.
 Once this PR is merged, an MR will need to be created againts the corresponding
 `resourceTemplate`(s) and namespace(s) in `app-interface`: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/insights/rbac/deploy.yml
 to bump the `ref` which will deploy your changes to the specified environment(s).
+
+Admin Role
+==========
+We added support for the new role flag "admin_default", similar to “platform_default”, to allow for admin roles to automatically be assigned to org admins (not admins via the RBAC admin role). By default we will have the "admin_default" flag set to false. An example of what an admin role only assigned to admins by default may look like:
+
+```json
+{
+  "roles": [
+    {
+      "name": "Service administrator",
+      "description": "Perform any available operation against any Service resource.",
+      "system": true,
+      "platform_default": false,
+      "admin_default": true,
+      "version": 1,
+      "access": [
+        {
+          "permission": "service:*:*"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ exist for the current app/resource type.
 
 Please check existing files for more samples.
 
-Admin Role
-----------
+Admin Default Role
+------------------
 We added support for the new role flag "admin_default", similar to “platform_default”, to allow for admin roles to automatically be assigned to org admins (not admins via the RBAC admin role). By default we will have the "admin_default" flag set to false. An example of what an admin role only assigned to admins by default may look like:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -106,18 +106,8 @@ exist for the current app/resource type.
 
 Please check existing files for more samples.
 
-Deployment
-==========
-Once your PR is merged, an automated PR will be created with your changes applied as
-a ConfigMap in the templates within `/_private/configmaps/(ci|qa|stage|prod)/`
-for roles and permissions.
-
-Once this PR is merged, an MR will need to be created againts the corresponding
-`resourceTemplate`(s) and namespace(s) in `app-interface`: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/insights/rbac/deploy.yml
-to bump the `ref` which will deploy your changes to the specified environment(s).
-
 Admin Role
-==========
+----------
 We added support for the new role flag "admin_default", similar to “platform_default”, to allow for admin roles to automatically be assigned to org admins (not admins via the RBAC admin role). By default we will have the "admin_default" flag set to false. An example of what an admin role only assigned to admins by default may look like:
 
 ```json
@@ -139,3 +129,14 @@ We added support for the new role flag "admin_default", similar to “platform_d
   ]
 }
 ```
+
+Deployment
+==========
+Once your PR is merged, an automated PR will be created with your changes applied as
+a ConfigMap in the templates within `/_private/configmaps/(ci|qa|stage|prod)/`
+for roles and permissions.
+
+Once this PR is merged, an MR will need to be created againts the corresponding
+`resourceTemplate`(s) and namespace(s) in `app-interface`: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/services/insights/rbac/deploy.yml
+to bump the `ref` which will deploy your changes to the specified environment(s).
+

--- a/schemas/roles.schema
+++ b/schemas/roles.schema
@@ -82,7 +82,6 @@
             "description",
             "system",
             "platform_default",
-            "admin_default",
             "version",
             "access"
           ]

--- a/schemas/roles.schema
+++ b/schemas/roles.schema
@@ -18,6 +18,9 @@
           "platform_default": {
             "type": "boolean"
           },
+          "admin_default": {
+            "type": "boolean"
+          },
           "version": {
             "type": "integer"
           },
@@ -79,6 +82,7 @@
             "description",
             "system",
             "platform_default",
+            "admin_default",
             "version",
             "access"
           ]


### PR DESCRIPTION
I added a new flag, admin_default, to the role schema which will be "false" by default. This will be responsible for giving role's admin permissions and allowing the PR check to validate against the schema. I also updated the README to have an example role with this new flag and a brief description of what it does.