### PR TITLE
Add OCP Advisor roles and permissions for prod

### DIFF
--- a/configs/prod/permissions/ocp-advisor.json
+++ b/configs/prod/permissions/ocp-advisor.json
@@ -1,0 +1,22 @@
+{
+  "*": [
+    {
+      "verb": "*"
+    }
+  ],
+  "toggle-recommendations": [
+    {
+      "verb": "write"
+    }
+  ],
+  "recommendation-results": [
+    {
+      "verb": "read"
+    }
+  ],
+  "exports": [
+    {
+      "verb": "read"
+    }
+  ]
+}

--- a/configs/prod/roles/insights.json
+++ b/configs/prod/roles/insights.json
@@ -2,11 +2,11 @@
   "roles": [
     {
       "name": "Insights administrator",
-      "display_name": "Advisor administrator",
-      "description": "Perform any available operation against any advisor resource.",
+      "display_name": "RHEL Advisor administrator",
+      "description": "Perform any available operation against any RHEL Advisor resource.",
       "system": true,
       "platform_default": true,
-      "version": 9,
+      "version": 10,
       "access": [
         {
           "permission": "advisor:*:*"

--- a/configs/prod/roles/ocp-advisor.json
+++ b/configs/prod/roles/ocp-advisor.json
@@ -1,0 +1,17 @@
+{
+  "roles": [
+    {
+      "name": "OCP Advisor administrator",
+      "display_name": "OCP Advisor administrator",
+      "description": "Perform any available operation against any OCP Advisor resource.",
+      "system": true,
+      "platform_default": true,
+      "version": 1,
+      "access": [
+        {
+          "permission": "ocp-advisor:*:*"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Implements https://issues.redhat.com/browse/CCXDEV-7349.

There is a new application under c.r.c. called OCP Advisor which has a GA this week. This patch is another preparation step that updates the RBAC config in prod.