### PR TITLE
Bump catalog role versions

### DIFF
--- a/configs/prod/roles/catalog.json
+++ b/configs/prod/roles/catalog.json
@@ -4,7 +4,7 @@
       "name": "Catalog Administrator",
       "display_name": "Automation Services Catalog administrator",
       "system": true,
-      "version": 8,
+      "version": 9,
       "description": "A catalog administrator roles grants create,read,update, delete and order permissions",
       "access": [
         {
@@ -322,7 +322,7 @@
       "name": "Catalog User",
       "display_name": "Automation Services Catalog user",
       "system": true,
-      "version": 8,
+      "version": 9,
       "description": "A catalog user roles grants read and order permissions",
       "platform_default": true,
       "access": [

--- a/configs/stage/roles/catalog.json
+++ b/configs/stage/roles/catalog.json
@@ -4,7 +4,7 @@
       "name": "Catalog Administrator",
       "display_name": "Automation Services Catalog administrator",
       "system": true,
-      "version": 8,
+      "version": 9,
       "description": "A catalog administrator roles grants create,read,update, delete and order permissions",
       "access": [
         {
@@ -322,7 +322,7 @@
       "name": "Catalog User",
       "display_name": "Automation Services Catalog user",
       "system": true,
-      "version": 8,
+      "version": 9,
       "description": "A catalog user roles grants read and order permissions",
       "platform_default": true,
       "access": [


### PR DESCRIPTION
We need to bump the versions to pick the changes up from: https://github.com/RedHatInsights/rbac-config/pull/250/files

Disregarding ci/qa as they're no longer used.