### PR TITLE
fix: Changing default role to Compliance Administrator

### DIFF
--- a/configs/fedramp-stage/roles/compliance.json
+++ b/configs/fedramp-stage/roles/compliance.json
@@ -4,7 +4,8 @@
       "name": "Compliance administrator",
       "description": "A Compliance role that grants full access to any Compliance resource.",
       "system": true,
-      "version": 9,
+      "platform_default": true,
+      "version": 10,
       "access": [
         {
           "permission": "compliance:*:*"
@@ -47,8 +48,7 @@
       "name": "Compliance viewer",
       "description": "A Compliance role that grants read access to any Compliance resource.",
       "system": true,
-      "platform_default": true,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "compliance:policy:read"

--- a/configs/stage/roles/compliance.json
+++ b/configs/stage/roles/compliance.json
@@ -4,7 +4,8 @@
       "name": "Compliance administrator",
       "description": "A Compliance role that grants full access to any Compliance resource.",
       "system": true,
-      "version": 9,
+      "platform_default": true,
+      "version": 10,
       "access": [
         {
           "permission": "compliance:*:*"
@@ -47,8 +48,7 @@
       "name": "Compliance viewer",
       "description": "A Compliance role that grants read access to any Compliance resource.",
       "system": true,
-      "platform_default": true,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "compliance:policy:read"


### PR DESCRIPTION
Changing the default to the _Compliance Viewer_ role means that everyone loses the _Compliance Administrator_ access, and currently is rejecting everyone with the _Compliance Viewer_ role.

This changes default role back to _Compliance Administrator_.