### PR TITLE
vulnerability: add admin role to admin users, viewer to non-admin

### DIFF
--- a/configs/stage/roles/vulnerability.json
+++ b/configs/stage/roles/vulnerability.json
@@ -4,8 +4,9 @@
       "name": "Vulnerability administrator",
       "description": "Perform any available operation against any Vulnerability resource.",
       "system": true,
-      "platform_default": true,
-      "version": 9,
+      "platform_default": false,
+      "admin_default": true,
+      "version": 10,
       "access": [
         {
           "permission": "vulnerability:*:*"
@@ -25,8 +26,9 @@
       "name": "Vulnerability viewer",
       "description": "Read any Vulnerability resource.",
       "system": true,
-      "platform_default": false,
-      "version": 2,
+      "platform_default": true,
+      "admin_default": false,
+      "version": 3,
       "access": [
         {
           "permission": "vulnerability:vulnerability_results:read"


### PR DESCRIPTION
Leveraging new functionality announced on April 29th.
Admin users should be granted vulnerability administrator role by default and non-admin users should be granted read-only access (viewer role).