### PR TITLE
feat: Apply secure RBAC configuration and New Default Admin Group in prod

### DIFF
--- a/configs/prod/roles/drift.json
+++ b/configs/prod/roles/drift.json
@@ -4,11 +4,26 @@
       "name": "Drift analysis administrator",
       "description": "Perform any available operation against any Drift Analysis resource.",
       "system": true,
-      "platform_default": true,
-      "version": 8,
+      "admin_default": true,
+      "version": 9,
       "access": [
         {
-          "permission": "drift:*:*"
+          "permission": "drift:comparisons:read"
+        },
+        {
+          "permission": "drift:baselines:read"
+        },
+        {
+          "permission": "drift:baselines:write"
+        },
+        {
+          "permission": "drift:historical-system-profiles:read"
+        },
+        {
+          "permission": "drift:notifications:read"
+        },
+        {
+          "permission": "drift:notifications:write"
         },
         {
           "permission": "inventory:*:read"
@@ -30,6 +45,9 @@
         },
         {
           "permission": "drift:historical-system-profiles:read"
+        },
+        {
+          "permission": "drift:notifications:read"
         },
         {
           "permission": "inventory:*:read"

--- a/configs/prod/roles/drift.json
+++ b/configs/prod/roles/drift.json
@@ -14,6 +14,27 @@
           "permission": "inventory:*:read"
         }
       ]
+    },
+    {
+      "name": "Drift viewer",
+      "description": "Perform read only operation against Drift Analysis resources.",
+      "system": true,
+      "platform_default": true,
+      "version": 1,
+      "access": [
+        {
+          "permission": "drift:comparisons:read"
+        },
+        {
+          "permission": "drift:baselines:read"
+        },
+        {
+          "permission": "drift:historical-system-profiles:read"
+        },
+        {
+          "permission": "inventory:*:read"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Apply secure RBAC configuration to the platform default RBAC group 

Now the default are read only access to all drift resources

First need to validate and merge PR #318 

EVNT-697-prod