### PR TITLE
Stage role version bumps

### DIFF
--- a/configs/stage/roles/drift.json
+++ b/configs/stage/roles/drift.json
@@ -5,7 +5,7 @@
       "description": "Perform any available operation against any Drift Analysis resource.",
       "system": true,
       "admin_default": true,
-      "version": 9,
+      "version": 10,
       "access": [
         {
           "permission": "drift:comparisons:read"
@@ -29,7 +29,7 @@
       "description": "Perform read only operation against Drift Analysis resources.",
       "system": true,
       "platform_default": true,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "drift:comparisons:read"

--- a/configs/stage/roles/sources.json
+++ b/configs/stage/roles/sources.json
@@ -6,7 +6,7 @@
       "system": true,
       "platform_default": false,
       "admin_default": true,
-      "version": 3,
+      "version": 4,
       "access": [
         {
           "permission": "sources:*:*"


### PR DESCRIPTION
Stage role changes in https://github.com/RedHatInsights/rbac-config/pull/322/files were not successful, because of managed Kafka errors which short-circuited the role updates/creates.

We've since temporarily disabled notifications in stage, to rerun seeds.