### PR TITLE
Bump RBAC role in stage for Kafka testing

### DIFF
--- a/configs/stage/roles/rbac.json
+++ b/configs/stage/roles/rbac.json
@@ -19,7 +19,7 @@
       "description": "Grants a non-org admin read access to principals within user access.",
       "system": true,
       "platform_default": false,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "rbac:principal:read"


### PR DESCRIPTION
We experienced a kafka issue in stage on Monday which we need to confirm is resolved. In order to trigger the behavior, we need to run seeds which update a role. This will force an update on the "User Access principal viewer" role, which will attempt to send a kafka message.