### PR TITLE
Bump version of rbac stage role back down

### DIFF
--- a/configs/stage/roles/rbac.json
+++ b/configs/stage/roles/rbac.json
@@ -19,7 +19,7 @@
       "description": "Grants a non-org admin read access to principals within user access.",
       "system": true,
       "platform_default": false,
-      "version": 2,
+      "version": 1,
       "access": [
         {
           "permission": "rbac:principal:read"


### PR DESCRIPTION
Will trigger another seed run, but resets the version inline with prod.