### PR TITLE
Add Inventory Groups roles

### DIFF
--- a/configs/prod/permissions/inventory.json
+++ b/configs/prod/permissions/inventory.json
@@ -17,5 +17,16 @@
         {
             "verb": "*"
         }
+    ],
+    "groups": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        },
+        {
+            "verb": "*"
+        }
     ]
 }

--- a/configs/prod/roles/inventory.json
+++ b/configs/prod/roles/inventory.json
@@ -4,11 +4,70 @@
       "name": "Inventory administrator",
       "description": "Perform any available operation against any Inventory resource.",
       "system": true,
-      "platform_default": true,
-      "version": 2,
+      "platform_default": false,
+      "admin_default": false,
+      "version": 3,
       "access": [
         {
           "permission": "inventory:*:*"
+        }
+      ]
+    },
+    {
+      "name": "Inventory Hosts Administrator",
+      "description": "Be able to read and edit Inventory Hosts data.",
+      "system": true,
+      "platform_default": true,
+      "admin_default": true,
+      "version": 3,
+      "access": [
+        {
+          "permission": "inventory:hosts:write"
+        },
+        {
+          "permission": "inventory:hosts:read"
+        }
+      ]
+    },
+    {
+      "name": "Inventory Hosts Viewer",
+      "description": "Be able to read Inventory Hosts data.",
+      "system": true,
+      "platform_default": false,
+      "admin_default": false,
+      "version": 3,
+      "access": [
+        {
+          "permission": "inventory:hosts:read"
+        }
+      ]
+    },
+    {
+      "name": "Inventory Groups Administrator",
+      "description": "Be able to read and edit Inventory Groups data.",
+      "system": true,
+      "platform_default": false,
+      "admin_default": true,
+      "version": 3,
+      "access": [
+        {
+          "permission": "inventory:groups:write"
+        },
+        {
+          "permission": "inventory:groups:read"
+        }
+      ]
+    },
+    {
+      "name": "Inventory Groups Viewer",
+      "description": "Be able to read Inventory Groups data.",
+      "system": true,
+      "platform_default": false,
+      "admin_default": false,
+      "version": 3,
+      "access": [
+        {
+          "permission": "inventory:groups:read"
         }
       ]
     }

--- a/configs/stage/roles/inventory.json
+++ b/configs/stage/roles/inventory.json
@@ -4,11 +4,70 @@
       "name": "Inventory administrator",
       "description": "Perform any available operation against any Inventory resource.",
       "system": true,
-      "platform_default": true,
-      "version": 2,
+      "platform_default": false,
+      "admin_default": false,
+      "version": 3,
       "access": [
         {
           "permission": "inventory:*:*"
+        }
+      ]
+    },
+    {
+      "name": "Inventory Hosts Administrator",
+      "description": "Be able to read and edit Inventory Hosts data.",
+      "system": true,
+      "platform_default": true,
+      "admin_default": true,
+      "version": 3,
+      "access": [
+        {
+          "permission": "inventory:hosts:write"
+        },
+        {
+          "permission": "inventory:hosts:read"
+        }
+      ]
+    },
+    {
+      "name": "Inventory Hosts Viewer",
+      "description": "Be able to read Inventory Hosts data.",
+      "system": true,
+      "platform_default": false,
+      "admin_default": false,
+      "version": 3,
+      "access": [
+        {
+          "permission": "inventory:hosts:read"
+        }
+      ]
+    },
+    {
+      "name": "Inventory Groups Administrator",
+      "description": "Be able to read and edit Inventory Groups data.",
+      "system": true,
+      "platform_default": false,
+      "admin_default": true,
+      "version": 3,
+      "access": [
+        {
+          "permission": "inventory:groups:write"
+        },
+        {
+          "permission": "inventory:groups:read"
+        }
+      ]
+    },
+    {
+      "name": "Inventory Groups Viewer",
+      "description": "Be able to read Inventory Groups data.",
+      "system": true,
+      "platform_default": false,
+      "admin_default": false,
+      "version": 3,
+      "access": [
+        {
+          "permission": "inventory:groups:read"
         }
       ]
     }


### PR DESCRIPTION
Inventory Administrator role wasn't the default for admins, because it was default for everyone. But, the default user access group is editable and when the Inventory Administrator role is removed from it, the org admin automatically loses the permissions too. That's why I think the Inventory Administrator role should be default for admins too.

_EDIT: In addition to the original purpose of this PR, there are Inventory Groups roles added to the RBAC config. As part of that, there are new, more granular roles created. Now we can remove defaults from "Inventory Administrator" and make "Inventory Hosts Administrator" default instead._


### Links
[JIRA - Add Inventory Groups roles](https://issues.redhat.com/browse/RHCLOUD-23435)