### PR TITLE
Add basic roles/permissions for content-sources app

### DIFF
--- a/configs/stage/permissions/content-sources.json
+++ b/configs/stage/permissions/content-sources.json
@@ -1,0 +1,15 @@
+{
+    "repositories": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        }
+    ],
+    "*": [
+        {
+            "verb": "*"
+        }
+    ]
+}

--- a/configs/stage/roles/content-sources.json
+++ b/configs/stage/roles/content-sources.json
@@ -1,0 +1,32 @@
+{
+    "roles": [
+      {
+        "name": "Repositories administrator",
+        "description": "Perform any available operation against any repositories resource.",
+        "system": true,
+        "platform_default": false,
+        "admin_default": true,
+        "version": 2,
+        "access": [
+          {
+            "permission": "content-sources:repositories:read"
+          },
+          {
+            "permission": "content-sources:repositories:write"
+          }
+        ]
+      },
+      {
+        "name": "Repositories viewer",
+        "description": "Perform read only operations against repositories resources.",
+        "system": true,
+        "platform_default": true,
+        "version": 2,
+        "access": [
+          {
+            "permission": "content-sources:repositories:read"
+          }
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
These permissions are needed to enable permission integration on our platform.

Big thanks to @coderbydesign  for his help.

