### PR TITLE
Prod: Make Tasks role admin default

### DIFF
--- a/configs/prod/roles/tasks.json
+++ b/configs/prod/roles/tasks.json
@@ -5,7 +5,8 @@
       "description": "Perform any available operation against any Tasks resource.",
       "system": true,
       "platform_default": false,
-      "version": 1,
+      "admin_default": true,
+      "version": 2,
       "access": [
         {
           "permission": "tasks:*:*"


### PR DESCRIPTION
Tasks App should be available to org admins be default. 