### PR TITLE
ESSNTL-4070: add permissions related to groups

### DIFF
--- a/configs/stage/permissions/inventory.json
+++ b/configs/stage/permissions/inventory.json
@@ -17,5 +17,16 @@
         {
             "verb": "*"
         }
+    ],
+    "groups": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        },
+        {
+            "verb": "*"
+        }
     ]
 }


### PR DESCRIPTION
This PR relates to [ESSNTL-4070](https://issues.redhat.com/browse/ESSNTL-4070). It adds the new permissions required by Inventory Groups.