### PR TITLE
Add Default access OCM groups

### DIFF
--- a/configs/prod/roles/ocm.json
+++ b/configs/prod/roles/ocm.json
@@ -17,8 +17,8 @@
       "display_name": "OCM Cluster Provisioner",
       "description": "Grants permission to provision clusters",
       "system": true,
-      "platform_default": false,
-      "version": 2,
+      "platform_default": true,
+      "version": 3,
       "external": {
         "id": "ClusterProvisioner",
         "tenant": "ocm"
@@ -29,8 +29,8 @@
       "display_name": "OCM Cluster Viewer",
       "description": "Grants permission to view clusters",
       "system": true,
-      "platform_default": false,
-      "version": 2,
+      "platform_default": true,
+      "version": 3,
       "external": {
         "id": "ClusterViewer",
         "tenant": "ocm"

--- a/configs/stage/roles/ocm.json
+++ b/configs/stage/roles/ocm.json
@@ -17,8 +17,8 @@
       "display_name": "OCM Cluster Provisioner",
       "description": "Grants permission to provision clusters",
       "system": true,
-      "platform_default": false,
-      "version": 2,
+      "platform_default": true,
+      "version": 3,
       "external": {
         "id": "ClusterProvisioner",
         "tenant": "ocm"
@@ -29,8 +29,8 @@
       "display_name": "OCM Cluster Viewer",
       "description": "Grants permission to view clusters",
       "system": true,
-      "platform_default": false,
-      "version": 2,
+      "platform_default": true,
+      "version": 3,
       "external": {
         "id": "ClusterViewer",
         "tenant": "ocm"


### PR DESCRIPTION
OCM needs the Default access group to include two roles, `OCM Cluster Provisioner` and `OCM Cluster Viewer`.