### PR TITLE
Add 'User' suffix to provisioning roles

### DIFF
--- a/configs/stage/roles/provisioning.json
+++ b/configs/stage/roles/provisioning.json
@@ -27,10 +27,10 @@
             "permission": "provisioning:reservation.gcp:read"
         }]
     }, {
-        "name": "Launch on AWS",
+        "name": "Launch on AWS User",
         "description": "An AWS launch role that grants write permissions on launch reservation and related resources.",
         "system": true,
-        "version": 1,
+        "version": 2,
         "access": [{
             "permission": "provisioning:source:*"
         }, {
@@ -41,10 +41,10 @@
             "permission": "provisioning:reservation.aws:*"
         }]
     }, {
-        "name": "Launch on Azure",
+        "name": "Launch on Azure User",
         "description": "An Azure launch role that grants write permissions on launch reservation and related resources.",
         "system": true,
-        "version": 1,
+        "version": 2,
         "access": [{
             "permission": "provisioning:source:*"
         }, {
@@ -55,10 +55,10 @@
             "permission": "provisioning:reservation.azure:*"
         }]
     }, {
-        "name": "Launch on Google Cloud",
+        "name": "Launch on Google Cloud User",
         "description": "An Google Cloud launch role that grants write permissions on launch reservation and related resources.",
         "system": true,
-        "version": 1,
+        "version": 2,
         "access": [{
             "permission": "provisioning:source:*"
         }, {


### PR DESCRIPTION
This patch just renames three roles, I am following @lpichler 's recommendation in https://github.com/RedHatInsights/rbac-config/pull/359/files to have a common suffix for all roles. I also bumped the version numbers.

Thanks.