### PR TITLE
Don't let org admin exec remediations by default

### DIFF
--- a/configs/stage/roles/remediations.json
+++ b/configs/stage/roles/remediations.json
@@ -5,8 +5,7 @@
       "description": "Perform any available operation against any Remediations resource",
       "system": true,
       "platform_default": false,
-      "admin_default": true,
-      "version": 6,
+      "version": 7,
       "access": [
         {
           "permission": "remediations:*:*"


### PR DESCRIPTION
Commercial stage and prod differ:

* Stage allows org admins to execute remediations by default.
* Prod doesn't allow org admins to execute remediations by default. They must assign themselves the "Remediations administrator" role.

This difference makes stage testing results less applicable to prod, which is a problem.

Fix: https://issues.redhat.com/browse/REMEDY-349