### PR TITLE
fix: Add wildcard permissions to Drift admin role

### DIFF
--- a/configs/prod/roles/drift.json
+++ b/configs/prod/roles/drift.json
@@ -5,7 +5,7 @@
       "description": "Perform any available operation against any Drift Analysis resource.",
       "system": true,
       "admin_default": true,
-      "version": 9,
+      "version": 10,
       "access": [
         {
           "permission": "drift:comparisons:read"
@@ -27,6 +27,9 @@
         },
         {
           "permission": "inventory:*:read"
+        },
+        {
+          "permission": "drift:*:*"
         }
       ]
     },

--- a/configs/stage/roles/drift.json
+++ b/configs/stage/roles/drift.json
@@ -5,7 +5,7 @@
       "description": "Perform any available operation against any Drift Analysis resource.",
       "system": true,
       "admin_default": true,
-      "version": 11,
+      "version": 12,
       "access": [
         {
           "permission": "drift:comparisons:read"
@@ -27,6 +27,9 @@
         },
         {
           "permission": "inventory:*:read"
+        },
+        {
+          "permission": "drift:*:*"
         }
       ]
     },


### PR DESCRIPTION
The drift admin role missed the wildcard permission `*:*`. This adds the missing permission to the role and makes it consistent with admin roles for other apps such as Inventory, Vulnerability, etc.

Duplicates https://github.com/RedHatInsights/rbac-config/pull/358.