### PR TITLE
Adding cost-mgmt setting permissions to stage.

### DIFF
--- a/configs/stage/permissions/cost-management.json
+++ b/configs/stage/permissions/cost-management.json
@@ -82,6 +82,17 @@
             "verb": "write"
         }
     ],
+    "settings": [
+        {
+            "verb": "*"
+        },
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        }
+    ],
     "*": [
         {
             "verb": "*"

--- a/configs/stage/roles/cost-management.json
+++ b/configs/stage/roles/cost-management.json
@@ -12,9 +12,11 @@
         "name": "Cost Price List Administrator",
         "description": "A cost management role that grants read and write permissions on cost models.",
         "system": true,
-        "version": 3,
+        "version": 4,
         "access": [{
             "permission": "cost-management:cost_model:*"
+        }, {
+            "permission": "cost-management:setting:*"
         }]
     }, {
         "name": "Cost Price List Viewer",


### PR DESCRIPTION
We are currently moving our settings page to under cost management. This PR is to create a settings permissions with read and write. 

Only modifying stage for now because we will be deprecating our old setting permissions on our backend that we will want to test in stage. 