### PR TITLE
OCM-2372 | feat: Seed OCM cluster-autoscaler roles in stage

### DIFF
--- a/configs/stage/roles/ocm.json
+++ b/configs/stage/roles/ocm.json
@@ -71,6 +71,18 @@
         "id": "OrganizationAdmin",
         "tenant": "ocm"
       }
+    },
+    {
+      "name": "OCM Cluster Autoscaler Editor",
+      "display_name": "OCM Cluster Autoscaler Editor",
+      "description": "Grants permission to edit cluster autoscaler",
+      "system": true,
+      "platform_default": false,
+      "version": 1,
+      "external": {
+        "id": "ClusterAutoscalerEditor",
+        "tenant": "ocm"
+      }
     }
   ]
 }


### PR DESCRIPTION
Adding a new role that is capable for creating, updating, and deleting cluster autoscalers via OCM API.

iiuc it depends on the actual implementation in the backend (CS & AMS).