### PR TITLE
[RHCLOUD-27429] Remove app-specific inventory:*:read permission 

### DIFF
--- a/configs/stage/roles/compliance.json
+++ b/configs/stage/roles/compliance.json
@@ -11,9 +11,6 @@
           "permission": "compliance:*:*"
         },
         {
-          "permission": "inventory:*:read"
-        },
-        {
           "permission": "remediations:remediation:read"
         },
         {
@@ -36,9 +33,6 @@
         },
         {
           "permission": "compliance:system:read"
-        },
-        {
-          "permission": "inventory:*:read"
         },
         {
           "permission": "remediations:remediation:read"

--- a/configs/stage/roles/config-manager.json
+++ b/configs/stage/roles/config-manager.json
@@ -22,9 +22,6 @@
           "permission": "config-manager:state-changes:read"
         },
         {
-          "permission": "inventory:*:read"
-        },
-        {
           "permission": "playbook-dispatcher:run:read",
           "resourceDefinitions": [
             {
@@ -57,9 +54,6 @@
         },
         {
           "permission": "config-manager:state-changes:read"
-        },
-        {
-          "permission": "inventory:*:read"
         },
         {
           "permission": "playbook-dispatcher:run:read",

--- a/configs/stage/roles/drift.json
+++ b/configs/stage/roles/drift.json
@@ -26,9 +26,6 @@
           "permission": "drift:notifications:write"
         },
         {
-          "permission": "inventory:*:read"
-        },
-        {
           "permission": "drift:*:*"
         }
       ]
@@ -51,9 +48,6 @@
         },
         {
           "permission": "drift:notifications:read"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/stage/roles/insights.json
+++ b/configs/stage/roles/insights.json
@@ -10,9 +10,6 @@
       "access": [
         {
           "permission": "advisor:*:*"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/stage/roles/malware-detection.json
+++ b/configs/stage/roles/malware-detection.json
@@ -10,9 +10,6 @@
       "access": [
         {
           "permission": "malware-detection:*:*"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     },
@@ -25,9 +22,6 @@
       "access": [
         {
           "permission": "malware-detection:*:read"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/stage/roles/patch.json
+++ b/configs/stage/roles/patch.json
@@ -12,9 +12,6 @@
           "permission": "patch:*:*"
         },
         {
-          "permission": "inventory:*:read"
-        },
-        {
           "permission": "remediations:*:read"
         },
         {
@@ -32,9 +29,6 @@
       "access": [
         {
           "permission": "patch:*:read"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/stage/roles/policies.json
+++ b/configs/stage/roles/policies.json
@@ -12,9 +12,6 @@
         },
         {
           "permission": "policies:policies:write"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     },
@@ -27,9 +24,6 @@
       "access": [
         {
           "permission": "policies:policies:read"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/stage/roles/remediations.json
+++ b/configs/stage/roles/remediations.json
@@ -11,9 +11,6 @@
           "permission": "remediations:*:*"
         },
         {
-          "permission": "inventory:*:read"
-        },
-        {
           "permission": "playbook-dispatcher:run:read",
           "resourceDefinitions": [
             {

--- a/configs/stage/roles/ros.json
+++ b/configs/stage/roles/ros.json
@@ -10,9 +10,6 @@
         "access": [
           {
             "permission": "ros:*:*"
-          },
-          {
-            "permission": "inventory:*:read"
           }
         ]
       },
@@ -25,9 +22,6 @@
         "access": [
           {
             "permission": "ros:*:read"
-          },
-          {
-            "permission": "inventory:*:read"
           }
         ]
       }

--- a/configs/stage/roles/subscriptions.json
+++ b/configs/stage/roles/subscriptions.json
@@ -11,9 +11,6 @@
       "access": [
         {
           "permission": "subscriptions:*:*"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     },
@@ -38,9 +35,6 @@
         },
         {
           "permission": "subscriptions:cloud_access:read"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/stage/roles/tasks.json
+++ b/configs/stage/roles/tasks.json
@@ -12,9 +12,6 @@
           "permission": "tasks:*:*"
         },
         {
-          "permission": "inventory:*:read"
-        },
-        {
           "permission": "playbook-dispatcher:run:read",
           "resourceDefinitions": [
             {

--- a/configs/stage/roles/vulnerability.json
+++ b/configs/stage/roles/vulnerability.json
@@ -12,9 +12,6 @@
           "permission": "vulnerability:*:*"
         },
         {
-          "permission": "inventory:*:read"
-        },
-        {
           "permission": "remediations:*:read"
         },
         {
@@ -38,9 +35,6 @@
         },
         {
           "permission": "vulnerability:report_and_export:read"
-        },
-        {
-          "permission": "inventory:*:read"
         },
         {
           "permission": "vulnerability:advanced_report:read"


### PR DESCRIPTION
Jira Ticket: [RHCLOUD-27249 ](https://issues.redhat.com/browse/RHCLOUD-27429)

This should not cause a disruption as the [`Inventory Hosts Administrator role`](https://github.com/RedHatInsights/rbac-config/blob/master/configs/stage/roles/inventory.json#L17) contains read/write permissions for hosts. 