### PR TITLE
Update platform default and promote provisioning roles/perms to prod

### DIFF
--- a/configs/prod/permissions/provisioning.json
+++ b/configs/prod/permissions/provisioning.json
@@ -1,0 +1,85 @@
+{
+    "source": [
+        {
+            "verb": "*"
+        },
+        {
+            "verb": "read"
+        }
+    ],
+    "pubkey": [
+        {
+            "verb": "*"
+        },
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write",
+            "requires": [
+                "read"
+            ]
+        }
+    ],
+    "reservation": [
+        {
+            "verb": "*"
+        },
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write",
+            "requires": [
+                "read"
+            ]
+        }
+    ],
+    "reservation.aws": [
+        {
+            "verb": "*"
+        },
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write",
+            "requires": [
+                "read"
+            ]
+        }
+    ],
+    "reservation.azure": [
+        {
+            "verb": "*"
+        },
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write",
+            "requires": [
+                "read"
+            ]
+        }
+    ],
+    "reservation.gcp": [
+        {
+            "verb": "*"
+        },
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write",
+            "requires": [
+                "read"
+            ]
+        }
+    ],
+    "*": [
+        {
+            "verb": "*"
+        }
+    ]
+}

--- a/configs/prod/roles/provisioning.json
+++ b/configs/prod/roles/provisioning.json
@@ -1,0 +1,73 @@
+{
+    "roles": [{
+        "name": "Launch Administrator",
+        "description": "An launch administrator role that grants read and write permissions.",
+        "system": true,
+        "admin_default": true,
+        "version": 1,
+        "access": [{
+            "permission": "provisioning:*:*"
+        }]
+    }, {
+        "name": "Launch Viewer",
+        "description": "An launch role that grants read permissions on launch reservation and related resources.",
+        "system": true,
+	"platform_default": true,
+        "version": 1,
+        "access": [{
+            "permission": "provisioning:source:read"
+        }, {
+            "permission": "provisioning:pubkey:read"
+        }, {
+            "permission": "provisioning:reservation:read"
+        }, {
+            "permission": "provisioning:reservation.aws:read"
+        }, {
+            "permission": "provisioning:reservation.azure:read"
+        }, {
+            "permission": "provisioning:reservation.gcp:read"
+        }]
+    }, {
+        "name": "Launch on AWS User",
+        "description": "An AWS launch role that grants write permissions on launch reservation and related resources.",
+        "system": true,
+        "version": 2,
+        "access": [{
+            "permission": "provisioning:source:*"
+        }, {
+            "permission": "provisioning:pubkey:*"
+        }, {
+            "permission": "provisioning:reservation:*"
+        }, {
+            "permission": "provisioning:reservation.aws:*"
+        }]
+    }, {
+        "name": "Launch on Azure User",
+        "description": "An Azure launch role that grants write permissions on launch reservation and related resources.",
+        "system": true,
+        "version": 2,
+        "access": [{
+            "permission": "provisioning:source:*"
+        }, {
+            "permission": "provisioning:pubkey:*"
+        }, {
+            "permission": "provisioning:reservation:*"
+        }, {
+            "permission": "provisioning:reservation.azure:*"
+        }]
+    }, {
+        "name": "Launch on Google Cloud User",
+        "description": "An Google Cloud launch role that grants write permissions on launch reservation and related resources.",
+        "system": true,
+        "version": 2,
+        "access": [{
+            "permission": "provisioning:source:*"
+        }, {
+            "permission": "provisioning:pubkey:*"
+        }, {
+            "permission": "provisioning:reservation:*"
+        }, {
+            "permission": "provisioning:reservation.gcp:*"
+        }]
+    }]
+}

--- a/configs/stage/roles/provisioning.json
+++ b/configs/stage/roles/provisioning.json
@@ -12,6 +12,7 @@
         "name": "Launch Viewer",
         "description": "An launch role that grants read permissions on launch reservation and related resources.",
         "system": true,
+	"platform_default": true,
         "version": 1,
         "access": [{
             "permission": "provisioning:source:read"


### PR DESCRIPTION
This promotes provisioning perms/roles, which are in stage for quite some time now, to prod.

No changes were made, these are copies of stage files.

Is it possible to get to production by Aug 13th? Thanks.