### PR TITLE
Add Hybrid Committed Spend roles and permissions in stage

### DIFF
--- a/configs/stage/permissions/hybrid-committed-spend.json
+++ b/configs/stage/permissions/hybrid-committed-spend.json
@@ -1,0 +1,7 @@
+{
+    "reports": [
+        {
+            "verb": "read"
+        }
+    ]
+}

--- a/configs/stage/roles/hybrid-committed-spend.json
+++ b/configs/stage/roles/hybrid-committed-spend.json
@@ -1,0 +1,17 @@
+{
+  "roles": [
+    {
+      "name": "Hybrid Committed Spend viewer",
+      "description": "View any Hybrid Committed Spend report.",
+      "system": false,
+      "admin_default": false,
+      "platform_default": false,
+      "version": 1,
+      "access": [
+        {
+          "permission": "hybrid-committed-spend:reports:read"
+        }
+      ]
+    }
+  ]
+}

--- a/configs/stage/roles/hybrid-committed-spend.json
+++ b/configs/stage/roles/hybrid-committed-spend.json
@@ -3,7 +3,7 @@
     {
       "name": "Hybrid Committed Spend viewer",
       "description": "View any Hybrid Committed Spend report.",
-      "system": false,
+      "system": true,
       "admin_default": false,
       "platform_default": false,
       "version": 1,


### PR DESCRIPTION
Hi,

console.redhat.com is accessing one of our APIs (billing.api.redhat.com) in order to retrieve Hybrid Commited Spend reports. This PR adds a role and a permission (in stage only, for now) that will be used to integrate our application with Console RBAC.

For reference: https://issues.redhat.com/browse/ITEAIFIN-2299

Thanks,

lorenzo