### PR TITLE
[RHCLOUD-27249] Remove app-specific inventory read permission from prod roles

### DIFF
--- a/configs/prod/roles/compliance.json
+++ b/configs/prod/roles/compliance.json
@@ -5,13 +5,10 @@
       "description": "A Compliance role that grants full access to any Compliance resource.",
       "system": true,
       "admin_default": true,
-      "version": 9,
+      "version": 10,
       "access": [
         {
           "permission": "compliance:*:*"
-        },
-        {
-          "permission": "inventory:*:read"
         },
         {
           "permission": "remediations:remediation:read"
@@ -26,7 +23,7 @@
       "description": "A Compliance role that grants read access to any Compliance resource.",
       "system": true,
       "platform_default": true,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "compliance:policy:read"
@@ -36,9 +33,6 @@
         },
         {
           "permission": "compliance:system:read"
-        },
-        {
-          "permission": "inventory:*:read"
         },
         {
           "permission": "remediations:remediation:read"

--- a/configs/prod/roles/config-manager.json
+++ b/configs/prod/roles/config-manager.json
@@ -7,7 +7,7 @@
       "system": true,
       "admin_default": true,
       "platform_default": false,
-      "version": 5,
+      "version": 6,
       "access": [
         {
           "permission": "config-manager:activation_keys:*"
@@ -20,9 +20,6 @@
         },
         {
           "permission": "config-manager:state-changes:read"
-        },
-        {
-          "permission": "inventory:*:read"
         },
         {
           "permission": "playbook-dispatcher:run:read",
@@ -47,7 +44,7 @@
       "description": "Can view the current configurations on RHC manager",
       "system": true,
       "platform_default": true,
-      "version": 5,
+      "version": 6,
       "access": [
         {
           "permission": "config-manager:activation_keys:read"
@@ -57,9 +54,6 @@
         },
         {
           "permission": "config-manager:state-changes:read"
-        },
-        {
-          "permission": "inventory:*:read"
         },
         {
           "permission": "playbook-dispatcher:run:read",

--- a/configs/prod/roles/drift.json
+++ b/configs/prod/roles/drift.json
@@ -5,7 +5,7 @@
       "description": "Perform any available operation against any Drift Analysis resource.",
       "system": true,
       "admin_default": true,
-      "version": 10,
+      "version": 11,
       "access": [
         {
           "permission": "drift:comparisons:read"
@@ -26,9 +26,6 @@
           "permission": "drift:notifications:write"
         },
         {
-          "permission": "inventory:*:read"
-        },
-        {
           "permission": "drift:*:*"
         }
       ]
@@ -38,7 +35,7 @@
       "description": "Perform read only operation against Drift Analysis resources.",
       "system": true,
       "platform_default": true,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "drift:comparisons:read"
@@ -51,9 +48,6 @@
         },
         {
           "permission": "drift:notifications:read"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/prod/roles/insights.json
+++ b/configs/prod/roles/insights.json
@@ -6,13 +6,10 @@
       "description": "Perform any available operation against any RHEL Advisor resource.",
       "system": true,
       "platform_default": true,
-      "version": 10,
+      "version": 11,
       "access": [
         {
           "permission": "advisor:*:*"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/prod/roles/malware-detection.json
+++ b/configs/prod/roles/malware-detection.json
@@ -6,13 +6,10 @@
       "description": "Perform any available operation against any malware-detection resource.",
       "system": true,
       "admin_default": true,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "malware-detection:*:*"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     },
@@ -21,13 +18,10 @@
       "display_name": "Malware detection viewer",
       "description": "Read any malware-detection resource.",
       "system": true,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "malware-detection:*:read"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/prod/roles/patch.json
+++ b/configs/prod/roles/patch.json
@@ -6,13 +6,10 @@
       "system": true,
       "platform_default": false,
       "admin_default": true,
-      "version": 8,
+      "version": 9,
       "access": [
         {
           "permission": "patch:*:*"
-        },
-        {
-          "permission": "inventory:*:read"
         },
         {
           "permission": "remediations:*:read"
@@ -28,13 +25,10 @@
       "system": true,
       "platform_default": true,
       "admin_default": false,
-      "version": 3,
+      "version": 4,
       "access": [
         {
           "permission": "patch:*:read"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/prod/roles/policies.json
+++ b/configs/prod/roles/policies.json
@@ -5,16 +5,13 @@
       "description": "Perform any available operation against any Policies resource.",
       "system": true,
       "admin_default": true,
-      "version": 6,
+      "version": 7,
       "access": [
         {
           "permission": "policies:policies:read"
         },
         {
           "permission": "policies:policies:write"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     },
@@ -23,13 +20,10 @@
       "description": "Perform read only operation against any Policies resource.",
       "system": true,
       "platform_default": true,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "policies:policies:read"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/prod/roles/remediations.json
+++ b/configs/prod/roles/remediations.json
@@ -5,13 +5,10 @@
       "description": "Perform any available operation against any Remediations resource",
       "system": true,
       "platform_default": false,
-      "version": 5,
+      "version": 6,
       "access": [
         {
           "permission": "remediations:*:*"
-        },
-        {
-          "permission": "inventory:*:read"
         },
         {
           "permission": "playbook-dispatcher:run:read",

--- a/configs/prod/roles/ros.json
+++ b/configs/prod/roles/ros.json
@@ -6,13 +6,10 @@
         "system": true,
         "platform_default": false,
         "admin_default": true,
-        "version": 2,
+        "version": 3,
         "access": [
           {
             "permission": "ros:*:*"
-          },
-          {
-            "permission": "inventory:*:read"
           }
         ]
       },
@@ -21,13 +18,10 @@
         "description": "A Resource Optimization user role that grants read only permission.",
         "system": true,
         "platform_default": true,
-        "version": 1,
+        "version": 2,
         "access": [
           {
             "permission": "ros:*:read"
-          },
-          {
-            "permission": "inventory:*:read"
           }
         ]
       }

--- a/configs/prod/roles/subscriptions.json
+++ b/configs/prod/roles/subscriptions.json
@@ -7,13 +7,10 @@
       "system": true,
       "admin_default": true,
       "platform_default": false,
-      "version": 6,
+      "version": 7,
       "access": [
         {
           "permission": "subscriptions:*:*"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     },
@@ -22,7 +19,7 @@
       "description": "View any Subscriptions resource.",
       "system": true,
       "platform_default": true,
-      "version": 3,
+      "version": 4,
       "access": [
         {
           "permission": "subscriptions:reports:read"
@@ -38,9 +35,6 @@
         },
         {
           "permission": "subscriptions:cloud_access:read"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     }

--- a/configs/prod/roles/tasks.json
+++ b/configs/prod/roles/tasks.json
@@ -6,13 +6,10 @@
       "system": true,
       "platform_default": false,
       "admin_default": true,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "tasks:*:*"
-        },
-        {
-          "permission": "inventory:*:read"
         },
         {
           "permission": "playbook-dispatcher:run:read",

--- a/configs/prod/roles/vulnerability.json
+++ b/configs/prod/roles/vulnerability.json
@@ -5,13 +5,10 @@
       "description": "Perform any available operation against any Vulnerability resource.",
       "system": true,
       "platform_default": true,
-      "version": 9,
+      "version": 10,
       "access": [
         {
           "permission": "vulnerability:*:*"
-        },
-        {
-          "permission": "inventory:*:read"
         },
         {
           "permission": "remediations:*:read"
@@ -26,7 +23,7 @@
       "description": "Read any Vulnerability resource.",
       "system": true,
       "platform_default": false,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "vulnerability:vulnerability_results:read"
@@ -36,9 +33,6 @@
         },
         {
           "permission": "vulnerability:report_and_export:read"
-        },
-        {
-          "permission": "inventory:*:read"
         },
         {
           "permission": "vulnerability:advanced_report:read"


### PR DESCRIPTION
Jira Ticket: [RHCLOUD-27249](https://issues.redhat.com/browse/RHCLOUD-27429)

This should not cause a disruption as the [Inventory Hosts Administrator role](https://github.com/RedHatInsights/rbac-config/blob/master/configs/stage/roles/inventory.json#L17) contains read/write permissions for hosts.