### PR TITLE
TEAMNADO-5688 - Update RHC Viewer to RHC User and change permission in Stage

### DIFF
--- a/configs/stage/roles/config-manager.json
+++ b/configs/stage/roles/config-manager.json
@@ -39,7 +39,7 @@
       ]
     },
     {
-      "name": "RHC User",
+      "name": "RHC Viewer",
       "display_name": "RHC user",
       "description": "Can view the current configurations on RHC manager and write to activation keys",
       "system": true,

--- a/configs/stage/roles/config-manager.json
+++ b/configs/stage/roles/config-manager.json
@@ -39,15 +39,15 @@
       ]
     },
     {
-      "name": "RHC Viewer",
-      "display_name": "RHC viewer",
-      "description": "Can view the current configurations on RHC manager",
+      "name": "RHC User",
+      "display_name": "RHC user",
+      "description": "Can view the current configurations on RHC manager and write to activation keys",
       "system": true,
       "platform_default": true,
       "version": 6,
       "access": [
         {
-          "permission": "config-manager:activation_keys:read"
+          "permission": "config-manager:activation_keys:write"
         },
         {
           "permission": "config-manager:state:read"

--- a/configs/stage/roles/config-manager.json
+++ b/configs/stage/roles/config-manager.json
@@ -44,7 +44,7 @@
       "description": "Can view the current configurations on RHC manager and write to activation keys",
       "system": true,
       "platform_default": true,
-      "version": 6,
+      "version": 7,
       "access": [
         {
           "permission": "config-manager:activation_keys:read"

--- a/configs/stage/roles/config-manager.json
+++ b/configs/stage/roles/config-manager.json
@@ -47,6 +47,9 @@
       "version": 6,
       "access": [
         {
+          "permission": "config-manager:activation_keys:read"
+        },
+        {
           "permission": "config-manager:activation_keys:write"
         },
         {


### PR DESCRIPTION
Per https://issues.redhat.com/browse/TEAMNADO-5688

This changes the `RHC Viewer` role to `RHC User` and updates permission to add `config-manager:activation_keys:write`

This change is only for Stage. After testing is complete in Stage we'll open up another PR for Prod.