### PR TITLE
Remove the staleness roles from the inventory config

### DIFF
--- a/configs/stage/permissions/inventory.json
+++ b/configs/stage/permissions/inventory.json
@@ -28,16 +28,5 @@
         {
             "verb": "*"
         }
-    ],
-    "staleness": [
-        {
-            "verb": "read"
-        },
-        {
-            "verb": "write"
-        },
-        {
-            "verb": "*"
-        }
     ]
 }

--- a/configs/stage/roles/inventory.json
+++ b/configs/stage/roles/inventory.json
@@ -70,37 +70,6 @@
           "permission": "inventory:groups:read"
         }
       ]
-    },
-    {
-      "name": "Account Staleness and Culling Administrator",
-      "description": "Be able to read and edit Account Staleness and Deletion data.",
-      "system": true,
-      "platform_default": false,
-      "admin_default": true,
-      "display_name": "Account Staleness and Deletion Administrator",
-      "version": 4,
-      "access": [
-        {
-          "permission": "inventory:staleness:write"
-        },
-        {
-          "permission": "inventory:staleness:read"
-        }
-      ]
-    },
-    {
-      "name": "Account Staleness and Culling Viewer",
-      "description": "Be able to read Account Staleness and Deletion data.",
-      "system": true,
-      "platform_default": true,
-      "admin_default": false,
-      "display_name": "Account Staleness and Deletion Viewer",
-      "version": 4,
-      "access": [
-        {
-          "permission": "inventory:staleness:read"
-        }
-      ]
     }
   ]
 }


### PR DESCRIPTION
We are having an issue with seeding. This role and permission is obsolete in the inventory application. Even though removing it from the config will not remove the role in the rbac-database, it might unlock seeding. Need to confirm that we can remove this before merging 