### PR TITLE
RHCLOUD-29986 | feature: make Notifications viewer as a default role

### DIFF
--- a/configs/prod/roles/notifications.json
+++ b/configs/prod/roles/notifications.json
@@ -20,8 +20,8 @@
       "name": "Notifications viewer",
       "description": "Read only access to notifications and integrations applications.",
       "system": true,
-      "platform_default": false,
-      "version": 2,
+      "platform_default": true,
+      "version": 3,
       "access": [
         {
           "permission": "notifications:notifications:read"

--- a/configs/stage/roles/notifications.json
+++ b/configs/stage/roles/notifications.json
@@ -20,8 +20,8 @@
       "name": "Notifications viewer",
       "description": "Read only access to notifications and integrations applications.",
       "system": true,
-      "platform_default": false,
-      "version": 2,
+      "platform_default": true,
+      "version": 3,
       "access": [
         {
           "permission": "notifications:notifications:read"


### PR DESCRIPTION
We want to encourage users to interact with Notifications more by at least allowing them to see what is configured for their tenants.

## Jira ticket
[[RHCLOUD-29986]](https://issues.redhat.com/browse/RHCLOUD-29986)