### PR TITLE
AAP-19521: Admin Dashboard: RBAC integration

### DIFF
--- a/configs/prod/permissions/ansible-wisdom-admin-dashboard.json
+++ b/configs/prod/permissions/ansible-wisdom-admin-dashboard.json
@@ -1,0 +1,20 @@
+{
+    "chart-recommendations": [
+        {
+            "verb": "read",
+            "description": "View the Recommendations Chart."
+        }
+    ],
+    "chart-user-sentiment": [
+        {
+            "verb": "read",
+            "description": "View the User Sentiment Chart."
+        }
+    ],
+    "chart-module-usage": [
+        {
+            "verb": "read",
+            "description": "View the Module Usage Chart."
+        }
+    ]
+}

--- a/configs/prod/roles/ansible-wisdom-admin-dashboard.json
+++ b/configs/prod/roles/ansible-wisdom-admin-dashboard.json
@@ -1,0 +1,17 @@
+{
+  "roles": [
+    {
+      "name": "Ansible Wisdom Admin Dashboard user",
+      "description": "An Ansible Wisdom Admin Dashboard user role that grants read permissions to Org Admins for all charts.",
+      "system": true,
+      "admin_default": true,
+      "platform_default": false,
+      "version": 1,
+      "access": [
+        {
+          "permission": "ansible-wisdom-admin-dashboard:*:*"
+        }
+      ]
+    }
+  ]
+}

--- a/configs/stage/permissions/ansible-wisdom-admin-dashboard.json
+++ b/configs/stage/permissions/ansible-wisdom-admin-dashboard.json
@@ -1,0 +1,20 @@
+{
+    "chart-recommendations": [
+        {
+            "verb": "read",
+            "description": "View the Recommendations Chart."
+        }
+    ],
+    "chart-user-sentiment": [
+        {
+            "verb": "read",
+            "description": "View the User Sentiment Chart."
+        }
+    ],
+    "chart-module-usage": [
+        {
+            "verb": "read",
+            "description": "View the Module Usage Chart."
+        }
+    ]
+}

--- a/configs/stage/roles/ansible-wisdom-admin-dashboard.json
+++ b/configs/stage/roles/ansible-wisdom-admin-dashboard.json
@@ -1,0 +1,17 @@
+{
+  "roles": [
+    {
+      "name": "Ansible Wisdom Admin Dashboard user",
+      "description": "An Ansible Wisdom Admin Dashboard user role that grants read permissions to Org Admins for all charts.",
+      "system": true,
+      "admin_default": true,
+      "platform_default": false,
+      "version": 1,
+      "access": [
+        {
+          "permission": "ansible-wisdom-admin-dashboard:*:*"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-19521

Following a [chat](https://redhat-internal.slack.com/archives/C0233N2MBU6/p1706115522125109) with @gmcculloug and @rabbott01 on `#team-consoledot-accessmanagement` this PR hopes to add role/permission configuration/mapping for "Org Admins" of the "Ansible Wisdom Admin Dashboard" into HCC's RBAC.

**ROMS**
https://issues.redhat.com/browse/PLMPGM-3847

**AppSRE Onboarding**
https://issues.redhat.com/browse/SDE-3776

In the absence of any _naming_ guidelines this follows the naming used in [`app-interface`](https://gitlab.cee.redhat.com/service/app-interface/-/tree/master/data/services/insights/ansible-wisdom-admin-dashboard?ref_type=heads).