### PR TITLE
HMS-3520: add idmsvc permissions and default roles

### DIFF
--- a/configs/stage/permissions/idmsvc.json
+++ b/configs/stage/permissions/idmsvc.json
@@ -1,0 +1,29 @@
+{
+    "token": [
+        {
+            "verb": "create"
+        }
+    ],
+    "domains": [
+        {
+            "verb": "list"
+        },
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "create"
+        },
+        {
+            "verb": "update"
+        },
+        {
+            "verb": "delete"
+        }
+    ],
+    "*": [
+        {
+            "verb": "*"
+        }
+    ]
+}

--- a/configs/stage/roles/idmsvc.json
+++ b/configs/stage/roles/idmsvc.json
@@ -1,0 +1,47 @@
+{
+  "roles": [
+    {
+      "name": "Domains administrator",
+      "description": "Perform any available operation against any domain resource.",
+      "system": true,
+      "platform_default": false,
+      "admin_default": true,
+      "version": 1,
+      "access": [
+        {
+          "permission": "idmsvc:token:create"
+        },
+        {
+          "permission": "idmsvc:domains:list"
+        },
+        {
+          "permission": "idmsvc:domains:read"
+        },
+        {
+          "permission": "idmsvc:domains:create"
+        },
+        {
+          "permission": "idmsvc:domains:update"
+        },
+        {
+          "permission": "idmsvc:domains:delete"
+        }
+      ]
+    },
+    {
+      "name": "Domains viewer",
+      "description": "Perform read only operations against domain resources.",
+      "system": true,
+      "platform_default": true,
+      "version": 1,
+      "access": [
+        {
+          "permission": "idmsvc:domains:list"
+        },
+        {
+          "permission": "idmsvc:domains:read"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This change provision and the configuration of the permissions and default roles that will manage the idmsvc microservice.

This provide the configuration for the stage environment.