### PR TITLE
AAP-21839: Ansible Lightspeed - Admin Dashboard: RBAC permissions for new Active Users chart

### DIFF
--- a/configs/prod/permissions/ansible-wisdom-admin-dashboard.json
+++ b/configs/prod/permissions/ansible-wisdom-admin-dashboard.json
@@ -16,5 +16,11 @@
             "verb": "read",
             "description": "View the Module Usage Chart."
         }
+    ],
+    "chart-active-users": [
+        {
+            "verb": "read",
+            "description": "View the Active Users Chart."
+        }
     ]
 }

--- a/configs/prod/roles/ansible-wisdom-admin-dashboard.json
+++ b/configs/prod/roles/ansible-wisdom-admin-dashboard.json
@@ -6,7 +6,7 @@
       "system": true,
       "admin_default": true,
       "platform_default": false,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "ansible-wisdom-admin-dashboard:chart-recommendations:read"
@@ -16,6 +16,9 @@
         },
         {
           "permission": "ansible-wisdom-admin-dashboard:chart-module-usage:read"
+        },
+        {
+          "permission": "ansible-wisdom-admin-dashboard:chart-active-users:read"
         }
       ]
     }

--- a/configs/stage/permissions/ansible-wisdom-admin-dashboard.json
+++ b/configs/stage/permissions/ansible-wisdom-admin-dashboard.json
@@ -16,5 +16,11 @@
             "verb": "read",
             "description": "View the Module Usage Chart."
         }
+    ],
+    "chart-active-users": [
+        {
+            "verb": "read",
+            "description": "View the Active Users Chart."
+        }
     ]
 }

--- a/configs/stage/roles/ansible-wisdom-admin-dashboard.json
+++ b/configs/stage/roles/ansible-wisdom-admin-dashboard.json
@@ -6,7 +6,7 @@
       "system": true,
       "admin_default": true,
       "platform_default": false,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "ansible-wisdom-admin-dashboard:chart-recommendations:read"
@@ -16,6 +16,9 @@
         },
         {
           "permission": "ansible-wisdom-admin-dashboard:chart-module-usage:read"
+        },
+        {
+          "permission": "ansible-wisdom-admin-dashboard:chart-active-users:read"
         }
       ]
     }


### PR DESCRIPTION
See https://issues.redhat.com/browse/AAP-21839

This PR is a continuation for https://github.com/RedHatInsights/rbac-config/pull/485, by adding role permissions for a new chart.

Thanks!