### PR TITLE
[RHCLOUD-35333] add the system role Vulnerability viewer into Default access group

### DIFF
--- a/configs/prod/roles/vulnerability.json
+++ b/configs/prod/roles/vulnerability.json
@@ -22,8 +22,9 @@
       "name": "Vulnerability viewer",
       "description": "Perform read operations on any Vulnerability resource.",
       "system": true,
-      "platform_default": false,
-      "version": 4,
+      "platform_default": true,
+      "admin_default": false,
+      "version": 5,
       "access": [
         {
           "permission": "vulnerability:vulnerability_results:read"


### PR DESCRIPTION
this change will not affect customers because right now the **Vulnerability administrator** is `platform_default=true`

the current state of Vulnerability system roles in production:
- **Vulnerability administrator** is part of **Default Access** group (with `platform_default=true` flag)
- **Vulnerability viewer** is not part of default groups (without a flag)

the expected state:
- **Vulnerability administrator** is part of **Default Admin Access** group (with `admin_default=true`)
- **Vulnerability viewer** is part of **Default Access** group (with `platform_default=true`)

this PR will fix only the **Vulnerability viewer** role
