### PR TITLE
feat(HMS-4705): update rbac-config roles (prod)

### DIFF
--- a/configs/prod/permissions/idmsvc.json
+++ b/configs/prod/permissions/idmsvc.json
@@ -1,0 +1,29 @@
+{
+    "token": [
+        {
+            "verb": "create"
+        }
+    ],
+    "domains": [
+        {
+            "verb": "list"
+        },
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "create"
+        },
+        {
+            "verb": "update"
+        },
+        {
+            "verb": "delete"
+        }
+    ],
+    "*": [
+        {
+            "verb": "*"
+        }
+    ]
+}

--- a/configs/prod/roles/idmsvc.json
+++ b/configs/prod/roles/idmsvc.json
@@ -1,0 +1,49 @@
+{
+  "roles": [
+    {
+      "name": "Domains administrator",
+      "display_name": "Directory and Domain Services administrator",
+      "description": "Create, read, update and delete Directory and Domains Services registrations.",
+      "system": true,
+      "platform_default": false,
+      "admin_default": true,
+      "version": 1,
+      "access": [
+        {
+          "permission": "idmsvc:token:create"
+        },
+        {
+          "permission": "idmsvc:domains:list"
+        },
+        {
+          "permission": "idmsvc:domains:read"
+        },
+        {
+          "permission": "idmsvc:domains:create"
+        },
+        {
+          "permission": "idmsvc:domains:update"
+        },
+        {
+          "permission": "idmsvc:domains:delete"
+        }
+      ]
+    },
+    {
+      "name": "Domains viewer",
+      "display_name": "Directory and Domain Services viewer",
+      "description": "Read Directory and Domains Services registrations.",
+      "system": true,
+      "platform_default": true,
+      "version": 1,
+      "access": [
+        {
+          "permission": "idmsvc:domains:list"
+        },
+        {
+          "permission": "idmsvc:domains:read"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This change copy the stage permissions and roles
for idmsvc to the prod directory, to make them
available before the service is deployed in prod.

https://issues.redhat.com/browse/HMS-4705