### PR TITLE
RHCLOUD-35560 - generate & validate schema before merging

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,21 +37,6 @@ jobs:
           ksl: configs/prod/schemas
           rbac_permissions: configs/prod/permissions
 
-      # convert configmaps & generate schemas
-      # same action as for generating, but we will not open a PR.
-      # this may be dangerous because if an existing branch is open with changes
-      # and someone else opens a PR that would nuke the branch/PR during just the run of this...
-      # without any changes being made.
-
-      # going to need to work around this...
-      # either need a action or copy the same commands.
-
-      # - name: Converting config to configmaps & generating schema
-      #   uses: RedHatInsights/rbac-config-actions/convert-config@main
-      #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     branch_name: configmaps-schema
-
       - name: Generate & validate schema
         uses: lennysgarage/rbac-config-actions/validate-schema@validate-schema
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,7 +38,7 @@ jobs:
           rbac_permissions: configs/prod/permissions
 
       - name: Generate & validate schema
-        uses: lennysgarage/rbac-config-actions/validate-schema@validate-schema
+        uses: RedHatInsights/rbac-config-actions/validate-schema@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,3 +22,47 @@ jobs:
         uses: RedHatInsights/rbac-config-actions/validate-permission-dependencies@main
         with:
           permissions_path_pattern: 'configs/**/*/permissions/*.json'
+
+      # Ensure that a proper valid schema is generated
+
+      # generate ksil json file
+      - name: Run Generate V1-Only Permissions Data for stage
+        uses: RedHatInsights/rbac-config-actions/generate-v1-only-permissions@main
+        with:
+          ksl: configs/stage/schemas
+          rbac_permissions: configs/stage/permissions
+      - name: Run Generate V1-Only Permissions Data for prod
+        uses: RedHatInsights/rbac-config-actions/generate-v1-only-permissions@main
+        with:
+          ksl: configs/prod/schemas
+          rbac_permissions: configs/prod/permissions
+
+      # convert configmaps & generate schemas
+      # same action as for generating, but we will not open a PR.
+      # this may be dangerous because if an existing branch is open with changes
+      # and someone else opens a PR that would nuke the branch/PR during just the run of this...
+      # without any changes being made.
+
+      # going to need to work around this...
+      # either need a action or copy the same commands.
+
+      # - name: Converting config to configmaps & generating schema
+      #   uses: RedHatInsights/rbac-config-actions/convert-config@main
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     branch_name: configmaps-schema
+
+      - name: Generate & validate schema
+        uses: lennysgarage/rbac-config-actions/validate-schema@validate-schema
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # validate generated schemas
+      - name: Validate Stage Schema
+        uses: "authzed/action-spicedb-validate@v1"
+        with:
+          validationfile: "configs/stage/schemas/schema.zed"
+      - name: Validate Prod Schema
+        uses: "authzed/action-spicedb-validate@v1"
+        with:
+          validationfile: "configs/prod/schemas/schema.zed"

--- a/configs/stage/schemas/src/notifications.ksl
+++ b/configs/stage/schemas/src/notifications.ksl
@@ -10,7 +10,7 @@ type integration {
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_subscribe_drawer')
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_subscribe_email')
     @rbac.add_v1_based_permission(app:'notifications', resource:'events', verb:'read', v2_perm:'notifications_event_log_view')
-    relation workspace: [ExctlyOn rbac.workspace]
+    relation workspace: [ExalyOn rbac.workspace]
 
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_view')
     relation view: workspace.notifications_integration_view

--- a/configs/stage/schemas/src/notifications.ksl
+++ b/configs/stage/schemas/src/notifications.ksl
@@ -10,7 +10,7 @@ type integration {
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_subscribe_drawer')
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_subscribe_email')
     @rbac.add_v1_based_permission(app:'notifications', resource:'events', verb:'read', v2_perm:'notifications_event_log_view')
-    relation workspace: [ExactlyOne rbac.workspace]
+    relation workspace: [ExctlyOn rbac.workspace]
 
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_view')
     relation view: workspace.notifications_integration_view

--- a/configs/stage/schemas/src/notifications.ksl
+++ b/configs/stage/schemas/src/notifications.ksl
@@ -10,7 +10,7 @@ type integration {
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_subscribe_drawer')
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_subscribe_email')
     @rbac.add_v1_based_permission(app:'notifications', resource:'events', verb:'read', v2_perm:'notifications_event_log_view')
-    relation workspace: [ExctlyOn rbac.workspace]
+    relation workspace: [ExactlyOne rbac.workspace]
 
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_view')
     relation view: workspace.notifications_integration_view

--- a/configs/stage/schemas/src/notifications.ksl
+++ b/configs/stage/schemas/src/notifications.ksl
@@ -10,7 +10,7 @@ type integration {
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_subscribe_drawer')
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_subscribe_email')
     @rbac.add_v1_based_permission(app:'notifications', resource:'events', verb:'read', v2_perm:'notifications_event_log_view')
-    relation workspace: [ExalyOn rbac.workspace]
+    relation workspace: [ExctlyOn rbac.workspace]
 
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_view')
     relation view: workspace.notifications_integration_view


### PR DESCRIPTION
Adds a PR check that generates a schema using the underlying ksl files and validates BEFORE merge.

Blocked by: https://github.com/RedHatInsights/rbac-config-actions/pull/17

Jira: [RHCLOUD-35560](https://issues.redhat.com/browse/RHCLOUD-35560)
Example of the action running in my fork: https://github.com/lennysgarage/rbac-config/pull/19 (no review needed here)