### PR TITLE
RHCLOUD-35813 | feature: remaining permissions for Notifications

### DIFF
--- a/configs/prod/schemas/src/notifications.ksl
+++ b/configs/prod/schemas/src/notifications.ksl
@@ -10,6 +10,11 @@ type integration {
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_subscribe_drawer')
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_subscribe_email')
     @rbac.add_v1_based_permission(app:'notifications', resource:'events', verb:'read', v2_perm:'notifications_event_log_view')
+    @rbac.add_v1_based_permission(app:'notifications', resource:'notifications', verb:'read', v2_perm:'notifications_behavior_groups_view')
+    @rbac.add_v1_based_permission(app:'notifications', resource:'notifications', verb:'write', v2_perm:'notifications_behavior_groups_edit')
+    @rbac.add_v1_based_permission(app:'notifications', resource:'notifications', verb:'read', v2_perm:'notifications_bundles_view')
+    @rbac.add_v1_based_permission(app:'notifications', resource:'notifications', verb:'read', v2_perm:'notifications_applications_view')
+    @rbac.add_v1_based_permission(app:'notifications', resource:'notifications', verb:'read', v2_perm:'notifications_event_types_view')
     relation workspace: [ExactlyOne rbac.workspace]
 
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_view')

--- a/configs/stage/schemas/src/notifications.ksl
+++ b/configs/stage/schemas/src/notifications.ksl
@@ -10,6 +10,11 @@ type integration {
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_subscribe_drawer')
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_subscribe_email')
     @rbac.add_v1_based_permission(app:'notifications', resource:'events', verb:'read', v2_perm:'notifications_event_log_view')
+    @rbac.add_v1_based_permission(app:'notifications', resource:'notifications', verb:'read', v2_perm:'notifications_behavior_groups_view')
+    @rbac.add_v1_based_permission(app:'notifications', resource:'notifications', verb:'write', v2_perm:'notifications_behavior_groups_edit')
+    @rbac.add_v1_based_permission(app:'notifications', resource:'notifications', verb:'read', v2_perm:'notifications_bundles_view')
+    @rbac.add_v1_based_permission(app:'notifications', resource:'notifications', verb:'read', v2_perm:'notifications_applications_view')
+    @rbac.add_v1_based_permission(app:'notifications', resource:'notifications', verb:'read', v2_perm:'notifications_event_types_view')
     relation workspace: [ExactlyOne rbac.workspace]
 
     @rbac.add_v1_based_permission(app:'notifications', resource:'integrations', verb:'read', v2_perm:'notifications_integration_view')


### PR DESCRIPTION
These temporary permissions will help us deal with the system data like bundles, applications and event types, and the tenant-specific data like behavior groups.

In the future we will refactor the system data calls in the Notifications code to comply with the Kessel style, by querying for the specific elements instead of querying for the broad workspace permissions.

## Jira ticket
[[RHCLOUD-35813]](https://issues.redhat.com/browse/RHCLOUD-35813)