### PR TITLE
fix malware-detection permission in RHEL roles

### DIFF
--- a/configs/stage/roles/rhel.json
+++ b/configs/stage/roles/rhel.json
@@ -108,7 +108,7 @@
       "system": true,
       "platform_default": false,
       "admin_default": false,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "advisor:*:*"
@@ -165,7 +165,7 @@
           "permission": "malware-detection:*:read"
         },
         {
-          "permission": "malware-detection:user_acknowledgement:write"
+          "permission": "malware-detection:acknowledgements:write"
         },
         {
           "permission": "notifications:notifications:read"
@@ -257,7 +257,7 @@
       "system": true,
       "platform_default": false,
       "admin_default": false,
-      "version": 2,
+      "version": 3,
       "access": [
         {
           "permission": "advisor:*:*"
@@ -341,7 +341,7 @@
           "permission": "malware-detection:*:*"
         },
         {
-          "permission": "malware-detection:user_acknowledgement:write"
+          "permission": "malware-detection:acknowledgements:write"
         },
         {
           "permission": "notifications:notifications:read"


### PR DESCRIPTION
the permission should be
`malware-detection:acknowledgements:write`

 https://github.com/RedHatInsights/rbac-config/blob/master/configs/stage/permissions/malware-detection.json 