### PR TITLE
Add temporary default role for testing the notifications sent post migration

### DIFF
--- a/configs/stage/roles/notifications.json
+++ b/configs/stage/roles/notifications.json
@@ -33,7 +33,7 @@
     },
     {
       "name": "Notifications tester",
-      "description": "Test read operations on notifications and integrations resources.",
+      "description": "Temporary role to test read operations on notifications.",
       "system": true,
       "platform_default": true,
       "version": 4,

--- a/configs/stage/roles/notifications.json
+++ b/configs/stage/roles/notifications.json
@@ -30,7 +30,18 @@
           "permission": "integrations:endpoints:read"
         }
       ]
+    },
+    {
+      "name": "Notifications tester",
+      "description": "Test read operations on notifications and integrations resources.",
+      "system": true,
+      "platform_default": true,
+      "version": 4,
+      "access": [
+        {
+          "permission": "notifications:notifications:read"
+        }
+      ]
     }
-
   ]
 }

--- a/configs/stage/roles/notifications.json
+++ b/configs/stage/roles/notifications.json
@@ -21,7 +21,7 @@
       "description": "Perform read operations on notifications and integrations resources.",
       "system": true,
       "platform_default": true,
-      "version": 4,
+      "version": 5,
       "access": [
         {
           "permission": "notifications:notifications:read"
@@ -30,18 +30,7 @@
           "permission": "integrations:endpoints:read"
         }
       ]
-    },
-    {
-      "name": "Notifications tester",
-      "description": "Temporary role to test read operations on notifications.",
-      "system": true,
-      "platform_default": true,
-      "version": 4,
-      "access": [
-        {
-          "permission": "notifications:notifications:read"
-        }
-      ]
     }
+
   ]
 }


### PR DESCRIPTION
Add a temporary role to stage that is a platform default role to test the number of tenants that are notified  