### PR TITLE
[RHCLOUD-39087] Remove permission from RHEL Operator Role

### DIFF
--- a/configs/stage/roles/rhel.json
+++ b/configs/stage/roles/rhel.json
@@ -90,7 +90,7 @@
       "system": true,
       "platform_default": false,
       "admin_default": false,
-      "version": 5,
+      "version": 6,
       "access": [
         {
           "permission": "advisor:*:*"
@@ -100,9 +100,6 @@
         },
         {
           "permission": "compliance:policy:update"
-        },
-        {
-          "permission": "compliance:policy:write"
         },
         {
           "permission": "compliance:report:read"


### PR DESCRIPTION
Related JIRA ticket: https://issues.redhat.com/browse/RHCLOUD-39087

After talking with Roman Blanco, he mentions that the RHEL operator role should not have the compliance:policy:create permission and that we should also remove the compliance:policy:write permission from the role. 

He mentions taking a look at D31 on this spreadsheet: https://docs.google.com/spreadsheets/d/1flNIAzhV71iON42xzPTanap0SXcOGExjjwVZn2pFohY/edit?gid=206369835#gid=206369835&range=E31

## Summary by Sourcery

Bug Fixes:
- Remove 'compliance:policy:write' permission from the RHEL Operator Role as per security recommendations