### PR TITLE
Update rhel.json

### DIFF
--- a/configs/stage/roles/rhel.json
+++ b/configs/stage/roles/rhel.json
@@ -102,9 +102,6 @@
           "permission": "compliance:policy:update"
         },
         {
-          "permission": "compliance:policy:write"
-        },
-        {
           "permission": "compliance:report:read"
         },
         {


### PR DESCRIPTION
Removing "compliance:policy:write" from RHEL Operator per @romanblanco comment on https://docs.google.com/spreadsheets/d/1flNIAzhV71iON42xzPTanap0SXcOGExjjwVZn2pFohY/edit?disco=AAABiZi5sF0

## Summary by Sourcery

Chores:
- Updated RHEL Operator role configuration to remove a specific permission based on review feedback