### PR TITLE
RHCLOUD-39124: Update hbi schema files

### DIFF
--- a/configs/prod/schemas/migrated_apps.lst
+++ b/configs/prod/schemas/migrated_apps.lst
@@ -1,3 +1,4 @@
 notifications
 integrations
 inventory
+staleness

--- a/configs/prod/schemas/src/hbi.ksl
+++ b/configs/prod/schemas/src/hbi.ksl
@@ -3,6 +3,9 @@ namespace hbi
 
 import rbac
 
+@rbac.add_v1_based_permission(app:'staleness', resource:'staleness', verb:'read', v2_perm:'staleness_staleness_view');
+@rbac.add_v1_based_permission(app:'staleness', resource:'staleness', verb:'write', v2_perm:'staleness_staleness_update');
+
 public type host {
     private relation workspace: [ExactlyOne rbac.workspace]
     

--- a/configs/stage/schemas/migrated_apps.lst
+++ b/configs/stage/schemas/migrated_apps.lst
@@ -1,3 +1,4 @@
 notifications
 integrations
 inventory
+staleness

--- a/configs/stage/schemas/src/hbi.ksl
+++ b/configs/stage/schemas/src/hbi.ksl
@@ -3,6 +3,9 @@ namespace hbi
 
 import rbac
 
+@rbac.add_v1_based_permission(app:'staleness', resource:'staleness', verb:'read', v2_perm:'staleness_staleness_view');
+@rbac.add_v1_based_permission(app:'staleness', resource:'staleness', verb:'write', v2_perm:'staleness_staleness_update');
+
 public type host {
     private relation workspace: [ExactlyOne rbac.workspace]
     


### PR DESCRIPTION
Closes: RHCLOUD-39124

Due to descoping, only the staleness permissions (at the workspace level) are needed for naive implementation.