### PR TITLE
Remove inventory permission in malware detection editor role (stage) 

### DIFF
--- a/configs/stage/roles/malware-detection.json
+++ b/configs/stage/roles/malware-detection.json
@@ -18,7 +18,7 @@
       "display_name": "Malware detection editor",
       "description": "Read any malware-detection resource as well as set malware acknowledgements.",
       "system": true,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "malware-detection:*:read"

--- a/configs/stage/roles/malware-detection.json
+++ b/configs/stage/roles/malware-detection.json
@@ -25,9 +25,6 @@
         },
         {
           "permission": "malware-detection:acknowledgements:write"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     },


### PR DESCRIPTION
This inventory permission here looks like an oversight and should not be needed \ present. 

Related to [RHINENG-18607](https://issues.redhat.com/browse/RHINENG-18607)