### PR TITLE
Remove inventory permission in malware detection editor role (prod)

### DIFF
--- a/configs/prod/roles/malware-detection.json
+++ b/configs/prod/roles/malware-detection.json
@@ -18,16 +18,13 @@
       "display_name": "Malware detection editor",
       "description": "Read any malware-detection resource as well as set malware acknowledgements.",
       "system": true,
-      "version": 1,
+      "version": 2,
       "access": [
         {
           "permission": "malware-detection:*:read"
         },
         {
           "permission": "malware-detection:acknowledgements:write"
-        },
-        {
-          "permission": "inventory:*:read"
         }
       ]
     },


### PR DESCRIPTION
This inventory permission here looks like an oversight and should not be needed \ present. 

Related to [this PR for stage](https://github.com/RedHatInsights/rbac-config/pull/613)
Related to [RHINENG-18607](https://issues.redhat.com/browse/RHINENG-18607)