### PR TITLE
RHCLOUD-41013 - Adding lock type to schema

### DIFF
--- a/configs/stage/schemas/src/kessel.ksl
+++ b/configs/stage/schemas/src/kessel.ksl
@@ -2,7 +2,7 @@ version 0.1
 namespace kessel
 
 internal type lock {
-    relation version: [ExactlyOne lockversion]
+    relation #version: [ExactlyOne lockversion]
 }
 
 internal type lockversion {}

--- a/configs/stage/schemas/src/kessel.ksl
+++ b/configs/stage/schemas/src/kessel.ksl
@@ -1,0 +1,8 @@
+version 0.1
+namespace kessel
+
+internal type lock {
+    relation version: [ExactlyOne lockversion]
+}
+
+internal type lockversion {}

--- a/configs/stage/schemas/src/rbac.ksl
+++ b/configs/stage/schemas/src/rbac.ksl
@@ -33,7 +33,6 @@ internal type role_binding { // TODO: revisit cardinality based on clamping deci
     relation role: [Any role]
 }
 
-
 //Placeholders for v1 inventory group permissions, will need to be mapped to v2 permissions as part of meta-authz for workspaces
 @add_v1only_permission(perm:'inventory_groups_read')
 @add_v1only_permission(perm:'inventory_groups_write')

--- a/configs/stage/schemas/src/rbac.ksl
+++ b/configs/stage/schemas/src/rbac.ksl
@@ -33,6 +33,12 @@ internal type role_binding { // TODO: revisit cardinality based on clamping deci
     relation role: [Any role]
 }
 
+public type lock {
+    relation version: [ExactlyOne lockversion]
+}
+
+public type lockversion {}
+
 //Placeholders for v1 inventory group permissions, will need to be mapped to v2 permissions as part of meta-authz for workspaces
 @add_v1only_permission(perm:'inventory_groups_read')
 @add_v1only_permission(perm:'inventory_groups_write')

--- a/configs/stage/schemas/src/rbac.ksl
+++ b/configs/stage/schemas/src/rbac.ksl
@@ -33,11 +33,6 @@ internal type role_binding { // TODO: revisit cardinality based on clamping deci
     relation role: [Any role]
 }
 
-public type lock {
-    relation version: [ExactlyOne lockversion]
-}
-
-public type lockversion {}
 
 //Placeholders for v1 inventory group permissions, will need to be mapped to v2 permissions as part of meta-authz for workspaces
 @add_v1only_permission(perm:'inventory_groups_read')


### PR DESCRIPTION
Adds a lock type to schema for stage, required for https://github.com/project-kessel/relations-api/pull/501

Jira: https://issues.redhat.com/browse/RHCLOUD-41013