### PR TITLE
Automate relations schema build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Schema build artifacts
+**/rbac_v1_permissions.json
+
+# Local test outputs
+_private/test-schema/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+init:
+	go install github.com/RedHatInsights/rbac-config-actions/generate-v1-only-permissions/cmd/generate-v1-only-permissions@latest
+	go install github.com/project-kessel/ksl-schema-language/cmd/ksl@latest
+
+# Stage environment targets
+configs/stage/schemas/src/rbac_v1_permissions.json: configs/stage/permissions/*.json configs/stage/schemas/*.lst
+	generate-v1-only-permissions -ksl configs/stage/schemas -rbac-permissions-json configs/stage/permissions
+
+configs/stage/schemas/schema.zed: configs/stage/schemas/src/*.ksl configs/stage/schemas/src/rbac_v1_permissions.json
+	ksl -o configs/stage/schemas/schema.zed configs/stage/schemas/src/*.ksl configs/stage/schemas/src/*.json
+
+ksl-schema-stage: configs/stage/schemas/schema.zed
+
+ksl-test-schema-stage: configs/stage/schemas/src/*.ksl configs/stage/schemas/src/rbac_v1_permissions.json
+	@mkdir -p _private/test-schema
+	ksl -o _private/test-schema/stage-schema.zed configs/stage/schemas/src/*.ksl configs/stage/schemas/src/*.json
+
+# Prod environment targets
+configs/prod/schemas/src/rbac_v1_permissions.json: configs/prod/permissions/*.json configs/prod/schemas/*.lst
+	generate-v1-only-permissions -ksl configs/prod/schemas -rbac-permissions-json configs/prod/permissions
+
+configs/prod/schemas/schema.zed: configs/prod/schemas/src/*.ksl configs/prod/schemas/src/rbac_v1_permissions.json
+	ksl -o configs/prod/schemas/schema.zed configs/prod/schemas/src/*.ksl configs/prod/schemas/src/*.json
+
+ksl-schema-prod: configs/prod/schemas/schema.zed
+
+ksl-test-schema-prod: configs/prod/schemas/src/*.ksl configs/prod/schemas/src/rbac_v1_permissions.json
+	@mkdir -p _private/test-schema
+	ksl -o _private/test-schema/prod-schema.zed configs/prod/schemas/src/*.ksl configs/prod/schemas/src/*.json


### PR DESCRIPTION
- Adds a makefile with targets to produce updated schemas as well as local test schemas
- Non-schema build artifacts (like rbac_v1_permissions.json) get excluded
- Local test schemas also get excluded

NOTE: this PR has external dependencies! Check:
- https://github.com/RedHatInsights/rbac-config-actions/pull/21
- https://github.com/project-kessel/ksl-schema-language/pull/34