### PR TITLE
feat: Add workspace permissions

### DIFF
--- a/configs/stage/permissions/workspaces.json
+++ b/configs/stage/permissions/workspaces.json
@@ -1,0 +1,24 @@
+{
+    "workspaces": [
+        {
+            "verb": "read",
+            "description": "View workspace"
+        },
+        {
+            "verb": "update",
+            "description": "Edit workspace (name or description)"
+        },
+        {
+            "verb": "create",
+            "description": "Create/add sub workspace (create new & move others under this workspace)"
+        },
+        {
+            "verb": "delete",
+            "description": "Delete sub workspace"
+        },
+        {
+            "verb": "link",
+            "description": "Move workspace (assign new parent)"
+        }
+    ]
+}


### PR DESCRIPTION
This commit adds a new permissions file for workspaces, defining the following permissions:

- View workspace
- Edit workspace (name or description)
- Create/add sub workspace
- Delete sub workspace
- Move workspace