### PR TITLE
Add rbac permission resources (assignments, groups, roles) to prod

### DIFF
--- a/configs/prod/permissions/rbac.json
+++ b/configs/prod/permissions/rbac.json
@@ -4,6 +4,30 @@
             "verb": "read"
         }
     ],
+    "assignments": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        }
+    ],
+    "groups": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        }
+    ],
+    "roles": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        }
+    ],
     "role_binding": [
         {
             "verb": "view"


### PR DESCRIPTION
## Summary
- Adds 3 missing RBAC permission resources to prod's `permissions/rbac.json` to match stage:
  - `assignments` (read, write)
  - `groups` (read, write)
  - `roles` (read, write)
- These are Kessel v2 permission primitives required for the RBAC service migration to the new authorization model

## Test plan
- [ ] Verify `configs/prod/permissions/rbac.json` now matches `configs/stage/permissions/rbac.json`
- [ ] Confirm schema validation passes
- [ ] Verify no impact on existing `principal`, `role_binding`, and `*` resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)