### PR TITLE
[RHCLOUD-45421] Add schema for tenant->role relationship

### DIFF
--- a/configs/stage/schemas/src/rbac.ksl
+++ b/configs/stage/schemas/src/rbac.ksl
@@ -37,6 +37,7 @@ internal type group {
 internal type role {
     private relation all_all_all: [bool]
     private relation child: [Any role]
+    relation owner: [ExactlyOne tenant]
 }
 
 internal type role_binding { // TODO: revisit cardinality based on clamping decisions
@@ -134,7 +135,7 @@ public extension add_unified_permission(app, resource, verb) {
         allow_duplicates private relation `${app}_${resource}_all`: [bool]
         allow_duplicates private relation `${app}_all_${verb}`: [bool]
 
-        relation `${app}_${resource}_${verb}`: [bool] or `${app}_${resource}_all` or `${app}_all_${verb}` or `${app}_all_all` or all_all_all or child.`${app}_${resource}_${verb}`
+        relation `${app}_${resource}_${verb}`: [bool] or `${app}_${resource}_all` or `${app}_all_${verb}` or `${app}_all_all` or all_all_all or child.`${app}_${resource}_${verb}` or owner.`${app}_${resource}_${verb}`
     }
 
     type role_binding {

--- a/configs/stage/schemas/src/rbac.ksl
+++ b/configs/stage/schemas/src/rbac.ksl
@@ -38,6 +38,8 @@ internal type role {
     private relation all_all_all: [bool]
     private relation child: [Any role]
     relation owner: [ExactlyOne tenant]
+    relation read: owner.rbac_roles_read
+    relation write: owner.rbac_roles_write
 }
 
 internal type role_binding { // TODO: revisit cardinality based on clamping decisions
@@ -135,7 +137,7 @@ public extension add_unified_permission(app, resource, verb) {
         allow_duplicates private relation `${app}_${resource}_all`: [bool]
         allow_duplicates private relation `${app}_all_${verb}`: [bool]
 
-        relation `${app}_${resource}_${verb}`: [bool] or `${app}_${resource}_all` or `${app}_all_${verb}` or `${app}_all_all` or all_all_all or child.`${app}_${resource}_${verb}` or owner.`${app}_${resource}_${verb}`
+        relation `${app}_${resource}_${verb}`: [bool] or `${app}_${resource}_all` or `${app}_all_${verb}` or `${app}_all_all` or all_all_all or child.`${app}_${resource}_${verb}`
     }
 
     type role_binding {


### PR DESCRIPTION
We are adding role to tenant relationships and this would allow assigning user the permission e.g. rbac_roles_read on tenant, and the user would also have rbac_roles_read  on the roles in the tenant

https://redhat.atlassian.net/browse/RHCLOUD-45421