### PR TITLE
RHINENG-25477 Fix advisor's recommendation_result permissions

### DIFF
--- a/configs/stage/schemas/src/advisor.ksl
+++ b/configs/stage/schemas/src/advisor.ksl
@@ -14,7 +14,7 @@ import hbi
 @rbac.add_v1_based_permission(app:'advisor', resource:'weekly_report_auto_subscribe', verb:'read', v2_perm:'advisor_weekly_report_auto_subscribe_view');
 @rbac.add_v1_based_permission(app:'advisor', resource:'weekly_report_auto_subscribe', verb:'write', v2_perm:'advisor_weekly_report_auto_subscribe_edit');
 
-@rbac.add_v1_based_permission(app:'advisor', resource:'recommendation_results', verb:'read', v2_perm:'advisor_recommendation_results_view_assigned');
-@rbac.add_v1_based_permission(app:'advisor', resource:'recommendation_results', verb:'write', v2_perm:'advisor_recommendation_results_edit_assigned');
+@rbac.add_v1_based_permission(app:'advisor', resource:'recommendation_results', verb:'read', v2_perm:'advisor_recommendation_results_view');
+@rbac.add_v1_based_permission(app:'advisor', resource:'recommendation_results', verb:'write', v2_perm:'advisor_recommendation_results_edit');
 
 @rbac.add_v1_based_permission(app:'advisor', resource:'exports', verb:'read', v2_perm:'advisor_exports_view');

--- a/configs/stage/schemas/src/advisor.ksl
+++ b/configs/stage/schemas/src/advisor.ksl
@@ -15,11 +15,6 @@ import hbi
 @rbac.add_v1_based_permission(app:'advisor', resource:'weekly_report_auto_subscribe', verb:'write', v2_perm:'advisor_weekly_report_auto_subscribe_edit');
 
 @rbac.add_v1_based_permission(app:'advisor', resource:'recommendation_results', verb:'read', v2_perm:'advisor_recommendation_results_view_assigned');
-@rbac.add_contingent_permission(first: 'inventory_host_view', second: 'advisor_recommendation_results_view_assigned', contingent: 'advisor_recommendation_results_view');
-@hbi.expose_host_permission(v2_perm: 'advisor_recommendation_results_view', host_perm: 'advisor_recommendation_results_view');
-
 @rbac.add_v1_based_permission(app:'advisor', resource:'recommendation_results', verb:'write', v2_perm:'advisor_recommendation_results_edit_assigned');
-@rbac.add_contingent_permission(first: 'inventory_host_view', second: 'advisor_recommendation_results_edit_assigned', contingent: 'advisor_recommendation_results_edit');
-@hbi.expose_host_permission(v2_perm: 'advisor_recommendation_results_edit', host_perm: 'advisor_recommendation_results_edit');
 
 @rbac.add_v1_based_permission(app:'advisor', resource:'exports', verb:'read', v2_perm:'advisor_exports_view');


### PR DESCRIPTION
 - view and edit are using the default workspace pattern, they should not be exposed to a host and should not use the inventory_host_view permission that might not be present in the default workspace at all.