### PR TITLE
RHCLOUD-35482: Add tenant relation to workspace

### DIFF
--- a/configs/stage/schemas/src/rbac.ksl
+++ b/configs/stage/schemas/src/rbac.ksl
@@ -27,6 +27,10 @@ internal type platform {
 internal type tenant {
     relation platform: [ExactlyOne platform]
     relation binding: [Any role_binding]
+
+    // Used in order to appease type checker in rbac/workspace. This should never be written to.
+    // This should be removed when rbac/workspace.parent becomes [AtMostOne workspace].
+    private relation tenant: [Any tenant]
 }
 
 internal type group {
@@ -50,6 +54,9 @@ internal type role_binding { // TODO: revisit cardinality based on clamping deci
 public type workspace { //Workspace is public so services can place resources into workspaces
     relation parent: [ExactlyOne workspace or tenant]
     relation binding: [Any role_binding] or parent.binding
+
+    // Explicitly defined on root workspaces, otherwise inherited from the parent workspace.
+    relation tenant: [AtMostOne tenant] or parent.tenant
 
 
     @add_v1_based_permission(app:'inventory', resource:'groups', verb:'read', v2_perm:'rbac_workspace_view')


### PR DESCRIPTION
In order to implement [RHCLOUD-35482](https://redhat.atlassian.net/browse/RHCLOUD-35482).

Add `tenant` relation to workspaces so that workspace-bound resources can define their own `tenant` relationship. This will be used for checking whether an arbitrary resources belongs to a specific tenant.

[RHCLOUD-35482]: https://redhat.atlassian.net/browse/RHCLOUD-35482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ