### PR TITLE
RHCLOUD-46155: Update workspace's parent relation to be AtMostOne

### DIFF
--- a/configs/stage/schemas/src/rbac.ksl
+++ b/configs/stage/schemas/src/rbac.ksl
@@ -52,7 +52,7 @@ internal type role_binding { // TODO: revisit cardinality based on clamping deci
 }
 
 public type workspace { //Workspace is public so services can place resources into workspaces
-    relation parent: [ExactlyOne workspace or tenant]
+    relation parent: [AtMostOne workspace or tenant]
     relation binding: [Any role_binding] or parent.binding
 
     // Explicitly defined on root workspaces, otherwise inherited from the parent workspace.


### PR DESCRIPTION
For [RHCLOUD-46155](https://redhat.atlassian.net/browse/RHCLOUD-46155).

We're going to be removing parent relations from root workspaces, so this can no longer be `ExactlyOne`. (We should do this before changing its type because the cardinality will still be incorrect even before we've removed *all* of the tenant parents.)

[RHCLOUD-46155]: https://redhat.atlassian.net/browse/RHCLOUD-46155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ