### PR TITLE
RHCLOUD-35482: Deploy workspace parent changes to prod

### DIFF
--- a/configs/prod/schemas/src/rbac.ksl
+++ b/configs/prod/schemas/src/rbac.ksl
@@ -22,6 +22,10 @@ internal type platform {
 internal type tenant {
     relation platform: [ExactlyOne platform]
     relation binding: [Any role_binding]
+
+    // Used in order to appease type checker in rbac/workspace. This should never be written to.
+    // This should be removed when rbac/workspace.parent becomes [AtMostOne workspace].
+    private relation tenant: [Any tenant]
 }
 
 internal type group {
@@ -43,8 +47,11 @@ internal type role_binding { // TODO: revisit cardinality based on clamping deci
 }
 
 public type workspace { //Workspace is public so services can place resources into workspaces
-    relation parent: [ExactlyOne workspace or tenant]
+    relation parent: [AtMostOne workspace or tenant]
     relation binding: [Any role_binding] or parent.binding
+
+    // Explicitly defined on root workspaces, otherwise inherited from the parent workspace.
+    relation tenant: [AtMostOne tenant] or parent.tenant
 
     @add_v1_based_permission(app:'inventory', resource:'groups', verb:'read', v2_perm:'rbac_workspace_view')
     relation view: rbac_workspace_view

--- a/configs/stage/schemas/src/rbac.ksl
+++ b/configs/stage/schemas/src/rbac.ksl
@@ -58,7 +58,6 @@ public type workspace { //Workspace is public so services can place resources in
     // Explicitly defined on root workspaces, otherwise inherited from the parent workspace.
     relation tenant: [AtMostOne tenant] or parent.tenant
 
-
     @add_v1_based_permission(app:'inventory', resource:'groups', verb:'read', v2_perm:'rbac_workspace_view')
     relation view: rbac_workspace_view
 


### PR DESCRIPTION
For [RHCLOUD-35482](https://redhat.atlassian.net/browse/RHCLOUD-35482).

Deploys the changes in #773 and #775 to prod.

(Also fix a formatting issue.)