### PR TITLE
RHCLOUD-35482: Add hbi/host tenant relation in stage

### DIFF
--- a/configs/stage/schemas/src/hbi.ksl
+++ b/configs/stage/schemas/src/hbi.ksl
@@ -8,6 +8,7 @@ import rbac
 
 public type host {
     private relation workspace: [ExactlyOne rbac.workspace]
+    relation tenant: workspace.tenant
     
     @rbac.add_v1_based_permission(app:'inventory', resource:'hosts', verb:'read', v2_perm:'inventory_host_view')
     relation view: workspace.inventory_host_view


### PR DESCRIPTION
For [RHCLOUD-35482](https://redhat.atlassian.net/browse/RHCLOUD-35482).

Allow checking the tenant of an `hbi/host` so that RBAC can prevent creating role bindings for a host in an incorrect tenant.

[RHCLOUD-35482]: https://redhat.atlassian.net/browse/RHCLOUD-35482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ