### PR TITLE
WIP: [stage] Added workspaces resource for subscriptions app 

### DIFF
--- a/configs/stage/permissions/subscriptions.json
+++ b/configs/stage/permissions/subscriptions.json
@@ -36,6 +36,14 @@
             "verb": "write"
         }
     ],
+    "workspaces": [
+        {
+            "verb": "read"
+        },
+        {
+            "verb": "write"
+        }
+    ],
     "*": [
         {
             "verb": "*"

--- a/configs/stage/roles/subscriptions.json
+++ b/configs/stage/roles/subscriptions.json
@@ -20,7 +20,7 @@
       "description": "Perform read operations on any Subscriptions resource.",
       "system": true,
       "platform_default": true,
-      "version": 8,
+      "version": 9,
       "access": [
         {
           "permission": "subscriptions:reports:read"
@@ -36,6 +36,9 @@
         },
         {
           "permission": "subscriptions:cloud_access:read"
+        },
+        {
+          "permission": "subscriptions:workspaces:read"
         }
       ]
     }


### PR DESCRIPTION
 This PR is aimed at adding new permissions in stage environment for workspaces resource.
  1. Added new permissions: `subscriptions:workspaces:read` and `subscriptions:workspaces:write`
  2. Modified "Subscriptions user" role to include read access to workspaces resource
  3. Updated role version from 8 to 9
  
  # JIRA:
 https://issues.redhat.com/browse/KATANA-397
  
  # Summary of changes:
  - Added workspaces resource to configs/stage/permissions/subscriptions.json with read and write verbs
  - Added subscriptions:workspaces:read permission to "Subscriptions user" role in configs/stage/roles/subscriptions.json
  - Incremented role version from 8 to 9
  - Only stage environment included (pre-prod)
  - Prod environment excluded (will be separate PR after verification)